### PR TITLE
Add `description` and `synonymous names`

### DIFF
--- a/docs/versions/v2.md
+++ b/docs/versions/v2.md
@@ -88,6 +88,11 @@ __references__ `list[string]`
 - Contains references to publications, databases, and arbitrary links to the web.
 
 
+__description__ `string`
+
+- Free-text field for further desctiptions of the experiment and dataset.
+
+
 __created__ `string`
 
 - Date the EnzymeML document was created.
@@ -287,6 +292,9 @@ __constant__* `boolean`
 
 
 - `Default`: false
+
+__synonymous_names__ `list[string]`
+
 
 __vessel_id__ `string`
 

--- a/enzymeml-go/src/v2.go
+++ b/enzymeml-go/src/v2.go
@@ -5,281 +5,221 @@
 
 package enzymeml
 
+import (
+	"encoding/json"
+	"fmt"
+)
 
 //
 // Type definitions
 //
 
-// EnzymeMLDocument This is the root object that composes all objects found in an EnzymeML
-// document. It also includes general metadata such as the name of
-// the document, when it was created/modified, and references to
-// publications, databases, and arbitrary links to the web.
+// EnzymeMLDocument
+//
+// This is the root object that composes all objects found in an EnzymeML document.
+// It also includes general metadata such as the name of the document, when
+// it was created/modified, and references to publications, databases, and
+// arbitrary links to the web.
 type EnzymeMLDocument struct {
-        // Title of the EnzymeML Document.
-        Name string `json:"name"`
-        // Contains references to publications, databases, and arbitrary links to
-        // the web.
-        References []string `json:"references,omitempty"`
-        // Date the EnzymeML document was created.
-        Created string `json:"created,omitempty"`
-        // Date the EnzymeML document was modified.
-        Modified string `json:"modified,omitempty"`
-        // Contains all authors that are part of the experiment.
-        Creators []Creator `json:"creators,omitempty"`
-        // Contains all vessels that are part of the experiment.
-        Vessels []Vessel `json:"vessels,omitempty"`
-        // Contains all proteins that are part of the experiment.
-        Proteins []Protein `json:"proteins,omitempty"`
-        // Contains all complexes that are part of the experiment.
-        Complexes []Complex `json:"complexes,omitempty"`
-        // Contains all reactants that are part of the experiment.
-        Small_molecules []SmallMolecule `json:"small_molecules,omitempty"`
-        // Dictionary mapping from reaction IDs to reaction-describing objects.
-        Reactions []Reaction `json:"reactions,omitempty"`
-        // Contains measurements that describe outcomes of an experiment.
-        Measurements []Measurement `json:"measurements,omitempty"`
-        // Contains ordinary differential equations that describe the kinetic
-        // model.
-        Equations []Equation `json:"equations,omitempty"`
-        // List of parameters that are part of the equation
-        Parameters []Parameter `json:"parameters,omitempty"`
+        ID *uint `json:"id,omitempty" xml:"id,attr,omitempty" gorm:"primaryKey,autoIncrement"`
+        Name string `json:"name" xml:"name" `
+        References []string `json:"references,omitempty" xml:"references,omitempty" `
+        Description string `json:"description,omitempty" xml:"description,omitempty" `
+        Created string `json:"created,omitempty" xml:"created,omitempty" `
+        Modified string `json:"modified,omitempty" xml:"modified,omitempty" `
+        Creators []Creator `json:"creators,omitempty" xml:"creators,omitempty" gorm:"many2many:enzymemldocument_creators;"`
+        Vessels []Vessel `json:"vessels,omitempty" xml:"vessels,omitempty" gorm:"many2many:enzymemldocument_vessels;"`
+        Proteins []Protein `json:"proteins,omitempty" xml:"proteins,omitempty" gorm:"many2many:enzymemldocument_proteins;"`
+        Complexes []Complex `json:"complexes,omitempty" xml:"complexes,omitempty" gorm:"many2many:enzymemldocument_complexes;"`
+        SmallMolecules []SmallMolecule `json:"small_molecules,omitempty" xml:"small_molecules,omitempty" gorm:"many2many:enzymemldocument_small_molecules;"`
+        Reactions []Reaction `json:"reactions,omitempty" xml:"reactions,omitempty" gorm:"many2many:enzymemldocument_reactions;"`
+        Measurements []Measurement `json:"measurements,omitempty" xml:"measurements,omitempty" gorm:"many2many:enzymemldocument_measurements;"`
+        Equations []Equation `json:"equations,omitempty" xml:"equations,omitempty" gorm:"many2many:enzymemldocument_equations;"`
+        Parameters []Parameter `json:"parameters,omitempty" xml:"parameters,omitempty" gorm:"many2many:enzymemldocument_parameters;"`
 }
 
-// Creator The creator object contains all information about authors that
-// contributed to the resulting document.
+// Creator
+//
+// The creator object contains all information about authors that contributed to
+// the resulting document.
 type Creator struct {
-        // Given name of the author or contributor.
-        Given_name string `json:"given_name"`
-        // Family name of the author or contributor.
-        Family_name string `json:"family_name"`
-        // Email address of the author or contributor.
-        Mail string `json:"mail"`
+        ID *uint `json:"id,omitempty" xml:"id,attr,omitempty" gorm:"primaryKey,autoIncrement"`
+        GivenName string `json:"given_name" xml:"given_name" `
+        FamilyName string `json:"family_name" xml:"family_name" `
+        Mail string `json:"mail" xml:"mail" `
 }
 
-// Vessel This object describes vessels in which the experiment has been carried
-// out. These can include any type of vessel used in biocatalytic
-// experiments.
+// Vessel
+//
+// This object describes vessels in which the experiment has been carried out.
+// These can include any type of vessel used in biocatalytic experiments.
 type Vessel struct {
-        // Unique identifier of the vessel.
-        Id string `json:"id"`
-        // Name of the used vessel.
-        Name string `json:"name"`
-        // Volumetric value of the vessel.
-        Volume float64 `json:"volume"`
-        // Volumetric unit of the vessel.
-        Unit UnitDefinition `json:"unit"`
-        // Whether the volume of the vessel is constant or not.
-        Constant bool `json:"constant"`
+        Id string `json:"id" xml:"id" gorm:"primaryKey"`
+        Name string `json:"name" xml:"name" `
+        Volume float64 `json:"volume" xml:"volume" `
+        Unit UnitDefinition `json:"unit" xml:"unit" `
+        Constant bool `json:"constant" xml:"constant" `
 }
 
-// Protein This object describes the proteins that were used or formed throughout
-// the experiment.
+// Protein
+//
+// This object describes the proteins that were used or formed throughout the
+// experiment.
 type Protein struct {
-        // Unique internal identifier of the protein.
-        Id string `json:"id"`
-        Name string `json:"name"`
-        Constant bool `json:"constant"`
-        // Amino acid sequence of the protein
-        Sequence string `json:"sequence,omitempty"`
-        // Unique identifier of the vessel this protein has been used in.
-        Vessel_id string `json:"vessel_id,omitempty"`
-        // EC number of the protein.
-        Ecnumber string `json:"ecnumber,omitempty"`
-        // Organism the protein was expressed in.
-        Organism string `json:"organism,omitempty"`
-        // Taxonomy identifier of the expression host.
-        Organism_tax_id string `json:"organism_tax_id,omitempty"`
-        // Array of references to publications, database entries, etc. that
-        // describe the protein.
-        References []string `json:"references,omitempty"`
+        Id string `json:"id" xml:"id" gorm:"primaryKey"`
+        Name string `json:"name" xml:"name" `
+        Constant bool `json:"constant" xml:"constant" `
+        Sequence string `json:"sequence,omitempty" xml:"sequence,omitempty" `
+        VesselId string `json:"vessel_id,omitempty" xml:"vessel_id,omitempty" `
+        Ecnumber string `json:"ecnumber,omitempty" xml:"ecnumber,omitempty" `
+        Organism string `json:"organism,omitempty" xml:"organism,omitempty" `
+        OrganismTaxId string `json:"organism_tax_id,omitempty" xml:"organism_tax_id,omitempty" `
+        References []string `json:"references,omitempty" xml:"references,omitempty" `
 }
 
-// Complex This object describes complexes made of reactants and/or proteins that
-// were used or produced in the course of the experiment.
+// Complex
+//
+// This object describes complexes made of reactants and/or proteins that were used
+// or produced in the course of the experiment.
 type Complex struct {
-        // Unique identifier of the complex.
-        Id string `json:"id"`
-        Name string `json:"name"`
-        Constant bool `json:"constant"`
-        // Unique identifier of the vessel this complex has been used in.
-        Vessel_id string `json:"vessel_id,omitempty"`
-        // Array of IDs the complex contains
-        Participants []string `json:"participants,omitempty"`
+        Id string `json:"id" xml:"id" gorm:"primaryKey"`
+        Name string `json:"name" xml:"name" `
+        Constant bool `json:"constant" xml:"constant" `
+        VesselId string `json:"vessel_id,omitempty" xml:"vessel_id,omitempty" `
+        Participants []string `json:"participants,omitempty" xml:"participants,omitempty" `
 }
 
-// SmallMolecule This object describes the reactants that were used or produced in the
-// course of the experiment.
+// SmallMolecule
+//
+// This object describes the reactants that were used or produced in the course of
+// the experiment.
 type SmallMolecule struct {
-        // Unique identifier of the small molecule.
-        Id string `json:"id"`
-        Name string `json:"name"`
-        Constant bool `json:"constant"`
-        // Unique identifier of the vessel this small molecule has been used in.
-        Vessel_id string `json:"vessel_id,omitempty"`
-        // Canonical Simplified Molecular-Input Line-Entry System (SMILES)
-        // encoding of the reactant.
-        Canonical_smiles string `json:"canonical_smiles,omitempty"`
-        // International Chemical Identifier (InChI) encoding of the reactant.
-        Inchi string `json:"inchi,omitempty"`
-        // Hashed International Chemical Identifier (InChIKey) encoding of the
-        // reactant.
-        Inchikey string `json:"inchikey,omitempty"`
-        // Array of references to publications, database entries, etc. that
-        // describe the reactant.
-        References []string `json:"references,omitempty"`
+        Id string `json:"id" xml:"id" gorm:"primaryKey"`
+        Name string `json:"name" xml:"name" `
+        Constant bool `json:"constant" xml:"constant" `
+        SynonymousNames []string `json:"synonymous_names,omitempty" xml:"synonymous_names,omitempty" `
+        VesselId string `json:"vessel_id,omitempty" xml:"vessel_id,omitempty" `
+        CanonicalSmiles string `json:"canonical_smiles,omitempty" xml:"canonical_smiles,omitempty" `
+        Inchi string `json:"inchi,omitempty" xml:"inchi,omitempty" `
+        Inchikey string `json:"inchikey,omitempty" xml:"inchikey,omitempty" `
+        References []string `json:"references,omitempty" xml:"references,omitempty" `
 }
 
-// Reaction This object describes a chemical or enzymatic reaction that was
-// investigated in the course of the experiment. All species used
-// within this object need to be part of the data model.
+// Reaction
+//
+// This object describes a chemical or enzymatic reaction that was investigated in
+// the course of the experiment. All species used within this object need to be
+// part of the data model.
 type Reaction struct {
-        // Unique identifier of the reaction.
-        Id string `json:"id"`
-        // Name of the reaction.
-        Name string `json:"name"`
-        // Whether the reaction is reversible or irreversible
-        Reversible bool `json:"reversible"`
-        // Mathematical expression of the reaction.
-        Kinetic_law Equation `json:"kinetic_law,omitempty"`
-        // List of reaction elements that are part of the reaction.
-        Species []ReactionElement `json:"species,omitempty"`
-        // List of reaction elements that are not part of the reaction but
-        // influence it.
-        Modifiers []string `json:"modifiers,omitempty"`
+        Id string `json:"id" xml:"id" gorm:"primaryKey"`
+        Name string `json:"name" xml:"name" `
+        Reversible bool `json:"reversible" xml:"reversible" `
+        KineticLaw Equation `json:"kinetic_law,omitempty" xml:"kinetic_law,omitempty" `
+        Species []ReactionElement `json:"species,omitempty" xml:"species,omitempty" gorm:"many2many:reaction_species;"`
+        Modifiers []string `json:"modifiers,omitempty" xml:"modifiers,omitempty" `
 }
 
-// ReactionElement This object is part of the Reaction object and describes either an
-// educt, product or modifier. The latter includes buffers, counter-
-// ions as well as proteins/enzymes.
+// ReactionElement
+//
+// This object is part of the Reaction object and describes either an educt,
+// product or modifier. The latter includes buffers, counter-ions as well as
+// proteins/enzymes.
 type ReactionElement struct {
-        // Internal identifier to either a protein or reactant defined in the
-        // EnzymeMLDocument.
-        Species_id string `json:"species_id"`
-        // Float number representing the associated stoichiometry.
-        Stoichiometry float64 `json:"stoichiometry"`
+        ID *uint `json:"id,omitempty" xml:"id,attr,omitempty" gorm:"primaryKey,autoIncrement"`
+        SpeciesId string `json:"species_id" xml:"species_id" `
+        Stoichiometry float64 `json:"stoichiometry" xml:"stoichiometry" `
 }
 
-// Equation This object describes an equation that can be used to model the
-// kinetics of a reaction. There are different types of equations
-// that can be used to model the kinetics of a reaction. The equation
-// can be an ordinary differential equation, a rate law or assignment
-// rule.
+// Equation
+//
+// This object describes an equation that can be used to model the kinetics of a
+// reaction. There are different types of equations that can be used to model
+// the kinetics of a reaction. The equation can be an ordinary differential
+// equation, a rate law or assignment rule.
 type Equation struct {
-        // Mathematical expression of the equation.
-        Equation string `json:"equation"`
-        // Type of the equation.
-        Equation_type EquationType `json:"equation_type"`
-        // Internal identifier to a species defined in the EnzymeMLDocument,
-        // given it is a rate equation.
-        Species_id string `json:"species_id,omitempty"`
-        // List of variables that are part of the equation
-        Variables []Variable `json:"variables,omitempty"`
+        ID *uint `json:"id,omitempty" xml:"id,attr,omitempty" gorm:"primaryKey,autoIncrement"`
+        Equation string `json:"equation" xml:"equation" `
+        EquationType EquationType `json:"equation_type" xml:"equation_type" `
+        SpeciesId string `json:"species_id,omitempty" xml:"species_id,omitempty" `
+        Variables []Variable `json:"variables,omitempty" xml:"variables,omitempty" gorm:"many2many:equation_variables;"`
 }
 
-// Variable This object describes a variable that is part of an equation.
+// Variable
+//
+// This object describes a variable that is part of an equation.
 type Variable struct {
-        // Unique identifier of the variable.
-        Id string `json:"id"`
-        // Name of the variable.
-        Name string `json:"name"`
-        // Symbol of the variable.
-        Symbol string `json:"symbol"`
+        Id string `json:"id" xml:"id" gorm:"primaryKey"`
+        Name string `json:"name" xml:"name" `
+        Symbol string `json:"symbol" xml:"symbol" `
 }
 
-// Parameter This object describes the parameters of the kinetic model and can
-// include all estimated values.
+// Parameter
+//
+// This object describes the parameters of the kinetic model and can include all
+// estimated values.
 type Parameter struct {
-        // Unique identifier of the parameter.
-        Id string `json:"id"`
-        // Name of the parameter.
-        Name string `json:"name"`
-        // Symbol of the parameter.
-        Symbol string `json:"symbol"`
-        // Numerical value of the estimated parameter.
-        Value float64 `json:"value,omitempty"`
-        // Unit of the estimated parameter.
-        Unit UnitDefinition `json:"unit,omitempty"`
-        // Initial value that was used for the parameter estimation.
-        Initial_value float64 `json:"initial_value,omitempty"`
-        // Upper bound of the estimated parameter.
-        Upper float64 `json:"upper,omitempty"`
-        // Lower bound of the estimated parameter.
-        Lower float64 `json:"lower,omitempty"`
-        // Standard error of the estimated parameter.
-        Stderr float64 `json:"stderr,omitempty"`
-        // Specifies if this parameter is constant
-        Constant bool `json:"constant,omitempty"`
+        Id string `json:"id" xml:"id" gorm:"primaryKey"`
+        Name string `json:"name" xml:"name" `
+        Symbol string `json:"symbol" xml:"symbol" `
+        Value float64 `json:"value,omitempty" xml:"value,omitempty" `
+        Unit UnitDefinition `json:"unit,omitempty" xml:"unit,omitempty" `
+        InitialValue float64 `json:"initial_value,omitempty" xml:"initial_value,omitempty" `
+        Upper float64 `json:"upper,omitempty" xml:"upper,omitempty" `
+        Lower float64 `json:"lower,omitempty" xml:"lower,omitempty" `
+        Stderr float64 `json:"stderr,omitempty" xml:"stderr,omitempty" `
+        Constant bool `json:"constant,omitempty" xml:"constant,omitempty" `
 }
 
-// Measurement This object describes the result of a measurement, which includes time
-// course data of any type defined in DataTypes. It includes initial
-// concentrations of all species used in a single measurement.
+// Measurement
+//
+// This object describes the result of a measurement, which includes time course
+// data of any type defined in DataTypes. It includes initial concentrations of
+// all species used in a single measurement.
 type Measurement struct {
-        // Unique identifier of the measurement.
-        Id string `json:"id"`
-        // Name of the measurement
-        Name string `json:"name"`
-        // Measurement data of all species that were part of the measurement. A
-        // species can refer to a protein, complex, or small molecule.
-        Species_data []MeasurementData `json:"species_data,omitempty"`
-        // User-defined group ID to signal relationships between measurements.
-        Group_id string `json:"group_id,omitempty"`
-        // PH value of the measurement.
-        Ph float64 `json:"ph,omitempty"`
-        // Temperature of the measurement.
-        Temperature float64 `json:"temperature,omitempty"`
-        // Unit of the temperature of the measurement.
-        Temperature_unit UnitDefinition `json:"temperature_unit,omitempty"`
+        Id string `json:"id" xml:"id" gorm:"primaryKey"`
+        Name string `json:"name" xml:"name" `
+        SpeciesData []MeasurementData `json:"species_data,omitempty" xml:"species_data,omitempty" gorm:"many2many:measurement_species_data;"`
+        GroupId string `json:"group_id,omitempty" xml:"group_id,omitempty" `
+        Ph float64 `json:"ph,omitempty" xml:"ph,omitempty" `
+        Temperature float64 `json:"temperature,omitempty" xml:"temperature,omitempty" `
+        TemperatureUnit UnitDefinition `json:"temperature_unit,omitempty" xml:"temperature_unit,omitempty" `
 }
 
-// MeasurementData This object describes a single entity of a measurement, which
-// corresponds to one species. It also holds replicates that contain
-// time course data.
+// MeasurementData
+//
+// This object describes a single entity of a measurement, which corresponds to one
+// species. It also holds replicates that contain time course data.
 type MeasurementData struct {
-        // The identifier for the described reactant.
-        Species_id string `json:"species_id"`
-        // Initial amount of the measurement data. This must be the same as the
-        // first data point in the array.
-        Initial float64 `json:"initial"`
-        // SI unit of the data that was measured.
-        Data_unit UnitDefinition `json:"data_unit"`
-        // Type of data that was measured (e.g. concentration)
-        Data_type DataTypes `json:"data_type"`
-        // Amount of the reactant before the measurement. This field should be
-        // used for specifying the prepared amount of a species in
-        // the reaction mix. Not to be confused with , specifying the
-        // concentration at the first data point from the array.
-        Prepared float64 `json:"prepared,omitempty"`
-        // Data that was measured.
-        Data []float64 `json:"data,omitempty"`
-        // Time steps of the replicate.
-        Time []float64 `json:"time,omitempty"`
-        // Time unit of the replicate.
-        Time_unit UnitDefinition `json:"time_unit,omitempty"`
-        // Whether or not the data has been generated by simulation.
-        Is_simulated bool `json:"is_simulated"`
+        ID *uint `json:"id,omitempty" xml:"id,attr,omitempty" gorm:"primaryKey,autoIncrement"`
+        SpeciesId string `json:"species_id" xml:"species_id" `
+        Initial float64 `json:"initial" xml:"initial" `
+        DataUnit UnitDefinition `json:"data_unit" xml:"data_unit" `
+        DataType DataTypes `json:"data_type" xml:"data_type" `
+        Prepared float64 `json:"prepared,omitempty" xml:"prepared,omitempty" `
+        Data []float64 `json:"data,omitempty" xml:"data,omitempty" `
+        Time []float64 `json:"time,omitempty" xml:"time,omitempty" `
+        TimeUnit UnitDefinition `json:"time_unit,omitempty" xml:"time_unit,omitempty" `
+        IsSimulated bool `json:"is_simulated" xml:"is_simulated" `
 }
 
-// UnitDefinition Represents a unit definition that is based on the SI unit system.
+// UnitDefinition
+//
+// Represents a unit definition that is based on the SI unit system.
 type UnitDefinition struct {
-        // Unique identifier of the unit definition.
-        Id string `json:"id,omitempty"`
-        // Common name of the unit definition.
-        Name string `json:"name,omitempty"`
-        // Base units that define the unit.
-        Base_units []BaseUnit `json:"base_units,omitempty"`
+        Id string `json:"id,omitempty" xml:"id,attr,omitempty" gorm:"primaryKey"`
+        Name string `json:"name,omitempty" xml:"name,attr,omitempty" `
+        BaseUnits []BaseUnit `json:"base_units,omitempty" xml:"base_units,omitempty" gorm:"many2many:unitdefinition_base_units;"`
 }
 
-// BaseUnit Represents a base unit in the unit definition.
+// BaseUnit
+//
+// Represents a base unit in the unit definition.
 type BaseUnit struct {
-        // Kind of the base unit (e.g., meter, kilogram, second).
-        Kind UnitType `json:"kind"`
-        // Exponent of the base unit in the unit definition.
-        Exponent int64 `json:"exponent"`
-        // Multiplier of the base unit in the unit definition.
-        Multiplier float64 `json:"multiplier,omitempty"`
-        // Scale of the base unit in the unit definition.
-        Scale float64 `json:"scale,omitempty"`
+        ID *uint `json:"id,omitempty" xml:"id,attr,omitempty" gorm:"primaryKey,autoIncrement"`
+        Kind UnitType `json:"kind" xml:"kind,attr" `
+        Exponent int64 `json:"exponent" xml:"exponent,attr" `
+        Multiplier float64 `json:"multiplier,omitempty" xml:"multiplier,attr,omitempty" `
+        Scale float64 `json:"scale,omitempty" xml:"scale,attr,omitempty" `
 }
 
 //
@@ -288,60 +228,56 @@ type BaseUnit struct {
 type EquationType string
 
 const (
-    EquationTypeASSIGNMENT EquationType = "assignment"
-    EquationTypeINITIAL_ASSIGNMENT EquationType = "initialAssignment"
-    EquationTypeODE EquationType = "ode"
-    EquationTypeRATE_LAW EquationType = "rateLaw"
+    ASSIGNMENT EquationType = "assignment"
+    INITIAL_ASSIGNMENT EquationType = "initialAssignment"
+    ODE EquationType = "ode"
+    RATE_LAW EquationType = "rateLaw"
 )
 type DataTypes string
 
 const (
-    DataTypesABSORBANCE DataTypes = "http://purl.allotrope.org/ontologies/quality#AFQ_0000061"
-    DataTypesCONCENTRATION DataTypes = "http://purl.obolibrary.org/obo/PATO_0000033"
-    DataTypesCONVERSION DataTypes = "http://purl.allotrope.org/ontologies/quality#AFQ_0000226"
-    DataTypesFLUORESCENCE DataTypes = "http://purl.obolibrary.org/obo/PATO_0000018"
-    DataTypesPEAK_AREA DataTypes = "http://purl.allotrope.org/ontologies/result#AFR_0001073"
-    DataTypesTRANSMITTANCE DataTypes = "http://purl.allotrope.org/ontologies/result#AFR_0002261"
+    ABSORBANCE DataTypes = "http://purl.allotrope.org/ontologies/quality#AFQ_0000061"
+    CONCENTRATION DataTypes = "http://purl.obolibrary.org/obo/PATO_0000033"
+    CONVERSION DataTypes = "http://purl.allotrope.org/ontologies/quality#AFQ_0000226"
+    FLUORESCENCE DataTypes = "http://purl.obolibrary.org/obo/PATO_0000018"
+    PEAK_AREA DataTypes = "http://purl.allotrope.org/ontologies/result#AFR_0001073"
+    TRANSMITTANCE DataTypes = "http://purl.allotrope.org/ontologies/result#AFR_0002261"
 )
 type UnitType string
 
 const (
-    UnitTypeAMPERE UnitType = "ampere"
-    UnitTypeAVOGADRO UnitType = "avogadro"
-    UnitTypeBECQUEREL UnitType = "becquerel"
-    UnitTypeCANDELA UnitType = "candela"
-    UnitTypeCELSIUS UnitType = "celsius"
-    UnitTypeCOULOMB UnitType = "coulomb"
-    UnitTypeDIMENSIONLESS UnitType = "dimensionless"
-    UnitTypeFARAD UnitType = "farad"
-    UnitTypeGRAM UnitType = "gram"
-    UnitTypeGRAY UnitType = "gray"
-    UnitTypeHENRY UnitType = "henry"
-    UnitTypeHERTZ UnitType = "hertz"
-    UnitTypeITEM UnitType = "item"
-    UnitTypeJOULE UnitType = "joule"
-    UnitTypeKATAL UnitType = "katal"
-    UnitTypeKELVIN UnitType = "kelvin"
-    UnitTypeKILOGRAM UnitType = "kilogram"
-    UnitTypeLITRE UnitType = "litre"
-    UnitTypeLUMEN UnitType = "lumen"
-    UnitTypeLUX UnitType = "lux"
-    UnitTypeMETRE UnitType = "metre"
-    UnitTypeMOLE UnitType = "mole"
-    UnitTypeNEWTON UnitType = "newton"
-    UnitTypeOHM UnitType = "ohm"
-    UnitTypePASCAL UnitType = "pascal"
-    UnitTypeRADIAN UnitType = "radian"
-    UnitTypeSECOND UnitType = "second"
-    UnitTypeSIEMENS UnitType = "siemens"
-    UnitTypeSIEVERT UnitType = "sievert"
-    UnitTypeSTERADIAN UnitType = "steradian"
-    UnitTypeTESLA UnitType = "tesla"
-    UnitTypeVOLT UnitType = "volt"
-    UnitTypeWATT UnitType = "watt"
-    UnitTypeWEBER UnitType = "weber"
+    AMPERE UnitType = "ampere"
+    AVOGADRO UnitType = "avogadro"
+    BECQUEREL UnitType = "becquerel"
+    CANDELA UnitType = "candela"
+    CELSIUS UnitType = "celsius"
+    COULOMB UnitType = "coulomb"
+    DIMENSIONLESS UnitType = "dimensionless"
+    FARAD UnitType = "farad"
+    GRAM UnitType = "gram"
+    GRAY UnitType = "gray"
+    HENRY UnitType = "henry"
+    HERTZ UnitType = "hertz"
+    ITEM UnitType = "item"
+    JOULE UnitType = "joule"
+    KATAL UnitType = "katal"
+    KELVIN UnitType = "kelvin"
+    KILOGRAM UnitType = "kilogram"
+    LITRE UnitType = "litre"
+    LUMEN UnitType = "lumen"
+    LUX UnitType = "lux"
+    METRE UnitType = "metre"
+    MOLE UnitType = "mole"
+    NEWTON UnitType = "newton"
+    OHM UnitType = "ohm"
+    PASCAL UnitType = "pascal"
+    RADIAN UnitType = "radian"
+    SECOND UnitType = "second"
+    SIEMENS UnitType = "siemens"
+    SIEVERT UnitType = "sievert"
+    STERADIAN UnitType = "steradian"
+    TESLA UnitType = "tesla"
+    VOLT UnitType = "volt"
+    WATT UnitType = "watt"
+    WEBER UnitType = "weber"
 )
-
-//
-// Type definitions for attributes with multiple types
-//

--- a/enzymeml-rs/src/versions/v2.rs
+++ b/enzymeml-rs/src/versions/v2.rs
@@ -4,162 +4,128 @@
 //! Do not edit directly - any changes will be overwritten.
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-
-// JSON-LD base types
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct JsonLdContext(pub HashMap<String, serde_json::Value>);
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct JsonLd {
-    #[serde(rename = "@context", skip_serializing_if = "Option::is_none")]
-    pub context: Option<JsonLdContext>,
-    #[serde(rename = "@id", skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
-    #[serde(rename = "@type", skip_serializing_if = "Option::is_none")]
-    pub type_: Option<String>,
-}
+use schemars::JsonSchema;
+use derive_builder::Builder;
 
 //
-// EnzymeML Type definitions
+// Type definitions
 //
 /// This is the root object that composes all objects found in an EnzymeML
 /// document. It also includes general metadata such as the name of
 /// the document, when it was created/modified, and references to
 /// publications, databases, and arbitrary links to the web.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Builder)]
+#[allow(non_snake_case)]
 pub struct EnzymeMLDocument {
-    #[serde(flatten)]
-    pub json_ld: JsonLd,
     /// Title of the EnzymeML Document.
     pub name: String,
-
     /// Contains references to publications, databases, and arbitrary links to
     /// the web.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub references: Option<Vec<String>>,
-
+    /// Free-text field for further desctiptions of the experiment and
+    /// dataset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     /// Date the EnzymeML document was created.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub created: Option<String>,
-
     /// Date the EnzymeML document was modified.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub modified: Option<String>,
-
     /// Contains all authors that are part of the experiment.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub creators: Option<Vec<Creator>>,
-
     /// Contains all vessels that are part of the experiment.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vessels: Option<Vec<Vessel>>,
-
     /// Contains all proteins that are part of the experiment.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proteins: Option<Vec<Protein>>,
-
     /// Contains all complexes that are part of the experiment.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub complexes: Option<Vec<Complex>>,
-
     /// Contains all reactants that are part of the experiment.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub small_molecules: Option<Vec<SmallMolecule>>,
-
     /// Dictionary mapping from reaction IDs to reaction-describing objects.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reactions: Option<Vec<Reaction>>,
-
     /// Contains measurements that describe outcomes of an experiment.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub measurements: Option<Vec<Measurement>>,
-
     /// Contains ordinary differential equations that describe the kinetic
     /// model.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub equations: Option<Vec<Equation>>,
-
     /// List of parameters that are part of the equation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
 
 }
 
+
 /// The creator object contains all information about authors that
 /// contributed to the resulting document.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Builder)]
+#[allow(non_snake_case)]
 pub struct Creator {
-    #[serde(flatten)]
-    pub json_ld: JsonLd,
     /// Given name of the author or contributor.
     pub given_name: String,
-
     /// Family name of the author or contributor.
     pub family_name: String,
-
     /// Email address of the author or contributor.
     pub mail: String,
 
 }
 
+
 /// This object describes vessels in which the experiment has been carried
 /// out. These can include any type of vessel used in biocatalytic
 /// experiments.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Builder)]
+#[allow(non_snake_case)]
 pub struct Vessel {
-    #[serde(flatten)]
-    pub json_ld: JsonLd,
     /// Unique identifier of the vessel.
     pub id: String,
-
     /// Name of the used vessel.
     pub name: String,
-
     /// Volumetric value of the vessel.
     pub volume: f64,
-
     /// Volumetric unit of the vessel.
     pub unit: UnitDefinition,
-
     /// Whether the volume of the vessel is constant or not.
     pub constant: bool,
 
 }
 
+
 /// This object describes the proteins that were used or formed throughout
 /// the experiment.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Builder)]
+#[allow(non_snake_case)]
 pub struct Protein {
-    #[serde(flatten)]
-    pub json_ld: JsonLd,
     /// Unique internal identifier of the protein.
     pub id: String,
 
     pub name: String,
 
     pub constant: bool,
-
     /// Amino acid sequence of the protein
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sequence: Option<String>,
-
     /// Unique identifier of the vessel this protein has been used in.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vessel_id: Option<String>,
-
     /// EC number of the protein.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ecnumber: Option<String>,
-
     /// Organism the protein was expressed in.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub organism: Option<String>,
-
     /// Taxonomy identifier of the expression host.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub organism_tax_id: Option<String>,
-
     /// Array of references to publications, database entries, etc. that
     /// describe the protein.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -167,35 +133,33 @@ pub struct Protein {
 
 }
 
+
 /// This object describes complexes made of reactants and/or proteins that
 /// were used or produced in the course of the experiment.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Builder)]
+#[allow(non_snake_case)]
 pub struct Complex {
-    #[serde(flatten)]
-    pub json_ld: JsonLd,
     /// Unique identifier of the complex.
     pub id: String,
 
     pub name: String,
 
     pub constant: bool,
-
     /// Unique identifier of the vessel this complex has been used in.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vessel_id: Option<String>,
-
     /// Array of IDs the complex contains
     #[serde(skip_serializing_if = "Option::is_none")]
     pub participants: Option<Vec<String>>,
 
 }
 
+
 /// This object describes the reactants that were used or produced in the
 /// course of the experiment.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Builder)]
+#[allow(non_snake_case)]
 pub struct SmallMolecule {
-    #[serde(flatten)]
-    pub json_ld: JsonLd,
     /// Unique identifier of the small molecule.
     pub id: String,
 
@@ -203,24 +167,22 @@ pub struct SmallMolecule {
 
     pub constant: bool,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub synonymous_names: Option<Vec<String>>,
     /// Unique identifier of the vessel this small molecule has been used in.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vessel_id: Option<String>,
-
     /// Canonical Simplified Molecular-Input Line-Entry System (SMILES)
     /// encoding of the reactant.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub canonical_smiles: Option<String>,
-
     /// International Chemical Identifier (InChI) encoding of the reactant.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inchi: Option<String>,
-
     /// Hashed International Chemical Identifier (InChIKey) encoding of the
     /// reactant.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inchikey: Option<String>,
-
     /// Array of references to publications, database entries, etc. that
     /// describe the reactant.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -228,30 +190,25 @@ pub struct SmallMolecule {
 
 }
 
+
 /// This object describes a chemical or enzymatic reaction that was
 /// investigated in the course of the experiment. All species used
 /// within this object need to be part of the data model.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Builder)]
+#[allow(non_snake_case)]
 pub struct Reaction {
-    #[serde(flatten)]
-    pub json_ld: JsonLd,
     /// Unique identifier of the reaction.
     pub id: String,
-
     /// Name of the reaction.
     pub name: String,
-
     /// Whether the reaction is reversible or irreversible
     pub reversible: bool,
-
     /// Mathematical expression of the reaction.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kinetic_law: Option<Equation>,
-
     /// List of reaction elements that are part of the reaction.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub species: Option<Vec<ReactionElement>>,
-
     /// List of reaction elements that are not part of the reaction but
     /// influence it.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -259,378 +216,301 @@ pub struct Reaction {
 
 }
 
+
 /// This object is part of the Reaction object and describes either an
 /// educt, product or modifier. The latter includes buffers, counter-
 /// ions as well as proteins/enzymes.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Builder)]
+#[allow(non_snake_case)]
 pub struct ReactionElement {
-    #[serde(flatten)]
-    pub json_ld: JsonLd,
     /// Internal identifier to either a protein or reactant defined in the
     /// EnzymeMLDocument.
     pub species_id: String,
-
     /// Float number representing the associated stoichiometry.
     pub stoichiometry: f64,
 
 }
+
 
 /// This object describes an equation that can be used to model the
 /// kinetics of a reaction. There are different types of equations
 /// that can be used to model the kinetics of a reaction. The equation
 /// can be an ordinary differential equation, a rate law or assignment
 /// rule.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Builder)]
+#[allow(non_snake_case)]
 pub struct Equation {
-    #[serde(flatten)]
-    pub json_ld: JsonLd,
     /// Mathematical expression of the equation.
     pub equation: String,
-
     /// Type of the equation.
     pub equation_type: EquationType,
-
     /// Internal identifier to a species defined in the EnzymeMLDocument,
     /// given it is a rate equation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub species_id: Option<String>,
-
     /// List of variables that are part of the equation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub variables: Option<Vec<Variable>>,
 
 }
 
+
 /// This object describes a variable that is part of an equation.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Builder)]
+#[allow(non_snake_case)]
 pub struct Variable {
-    #[serde(flatten)]
-    pub json_ld: JsonLd,
     /// Unique identifier of the variable.
     pub id: String,
-
     /// Name of the variable.
     pub name: String,
-
     /// Symbol of the variable.
     pub symbol: String,
 
 }
 
+
 /// This object describes the parameters of the kinetic model and can
 /// include all estimated values.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Builder)]
+#[allow(non_snake_case)]
 pub struct Parameter {
-    #[serde(flatten)]
-    pub json_ld: JsonLd,
     /// Unique identifier of the parameter.
     pub id: String,
-
     /// Name of the parameter.
     pub name: String,
-
     /// Symbol of the parameter.
     pub symbol: String,
-
     /// Numerical value of the estimated parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<f64>,
-
     /// Unit of the estimated parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unit: Option<UnitDefinition>,
-
     /// Initial value that was used for the parameter estimation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_value: Option<f64>,
-
     /// Upper bound of the estimated parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub upper: Option<f64>,
-
     /// Lower bound of the estimated parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lower: Option<f64>,
-
     /// Standard error of the estimated parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stderr: Option<f64>,
-
     /// Specifies if this parameter is constant
     #[serde(skip_serializing_if = "Option::is_none")]
     pub constant: Option<bool>,
 
 }
 
+
 /// This object describes the result of a measurement, which includes time
 /// course data of any type defined in DataTypes. It includes initial
 /// concentrations of all species used in a single measurement.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Builder)]
+#[allow(non_snake_case)]
 pub struct Measurement {
-    #[serde(flatten)]
-    pub json_ld: JsonLd,
     /// Unique identifier of the measurement.
     pub id: String,
-
     /// Name of the measurement
     pub name: String,
-
     /// Measurement data of all species that were part of the measurement. A
     /// species can refer to a protein, complex, or small molecule.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub species_data: Option<Vec<MeasurementData>>,
-
     /// User-defined group ID to signal relationships between measurements.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub group_id: Option<String>,
-
     /// PH value of the measurement.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ph: Option<f64>,
-
     /// Temperature of the measurement.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f64>,
-
     /// Unit of the temperature of the measurement.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature_unit: Option<UnitDefinition>,
 
 }
 
+
 /// This object describes a single entity of a measurement, which
 /// corresponds to one species. It also holds replicates that contain
 /// time course data.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Builder)]
+#[allow(non_snake_case)]
 pub struct MeasurementData {
-    #[serde(flatten)]
-    pub json_ld: JsonLd,
     /// The identifier for the described reactant.
     pub species_id: String,
-
     /// Initial amount of the measurement data. This must be the same as the
     /// first data point in the array.
     pub initial: f64,
-
     /// SI unit of the data that was measured.
     pub data_unit: UnitDefinition,
-
     /// Type of data that was measured (e.g. concentration)
     pub data_type: DataTypes,
-
     /// Amount of the reactant before the measurement. This field should
     /// be used for specifying the prepared amount of a species in
     /// the reaction mix. Not to be confused with , specifying the
     /// concentration at the first data point from the array.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prepared: Option<f64>,
-
     /// Data that was measured.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<Vec<f64>>,
-
     /// Time steps of the replicate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time: Option<Vec<f64>>,
-
     /// Time unit of the replicate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time_unit: Option<UnitDefinition>,
-
     /// Whether or not the data has been generated by simulation.
     pub is_simulated: bool,
 
 }
 
+
 /// Represents a unit definition that is based on the SI unit system.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Builder)]
+#[allow(non_snake_case)]
 pub struct UnitDefinition {
-    #[serde(flatten)]
-    pub json_ld: JsonLd,
     /// Unique identifier of the unit definition.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
-
     /// Common name of the unit definition.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-
     /// Base units that define the unit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub base_units: Option<Vec<BaseUnit>>,
 
 }
 
+
 /// Represents a base unit in the unit definition.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Builder)]
+#[allow(non_snake_case)]
 pub struct BaseUnit {
-    #[serde(flatten)]
-    pub json_ld: JsonLd,
     /// Kind of the base unit (e.g., meter, kilogram, second).
     pub kind: UnitType,
-
     /// Exponent of the base unit in the unit definition.
     pub exponent: i64,
-
     /// Multiplier of the base unit in the unit definition.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multiplier: Option<f64>,
-
     /// Scale of the base unit in the unit definition.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scale: Option<f64>,
 
 }
 
+
 //
-// EnzymeML Enum definitions
+// Enum definitions
 //
 
 #[allow(non_camel_case_types)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub enum EquationType {
     #[serde(rename = "assignment")]
     ASSIGNMENT,
-
     #[serde(rename = "initialAssignment")]
     INITIAL_ASSIGNMENT,
-
     #[serde(rename = "ode")]
     ODE,
-
     #[serde(rename = "rateLaw")]
     RATE_LAW,
-
 }
 
 
 #[allow(non_camel_case_types)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub enum DataTypes {
     #[serde(rename = "http://purl.allotrope.org/ontologies/quality#AFQ_0000061")]
     ABSORBANCE,
-
     #[serde(rename = "http://purl.obolibrary.org/obo/PATO_0000033")]
     CONCENTRATION,
-
     #[serde(rename = "http://purl.allotrope.org/ontologies/quality#AFQ_0000226")]
     CONVERSION,
-
     #[serde(rename = "http://purl.obolibrary.org/obo/PATO_0000018")]
     FLUORESCENCE,
-
     #[serde(rename = "http://purl.allotrope.org/ontologies/result#AFR_0001073")]
     PEAK_AREA,
-
     #[serde(rename = "http://purl.allotrope.org/ontologies/result#AFR_0002261")]
     TRANSMITTANCE,
-
 }
 
 
 #[allow(non_camel_case_types)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub enum UnitType {
     #[serde(rename = "ampere")]
     AMPERE,
-
     #[serde(rename = "avogadro")]
     AVOGADRO,
-
     #[serde(rename = "becquerel")]
     BECQUEREL,
-
     #[serde(rename = "candela")]
     CANDELA,
-
     #[serde(rename = "celsius")]
     CELSIUS,
-
     #[serde(rename = "coulomb")]
     COULOMB,
-
     #[serde(rename = "dimensionless")]
     DIMENSIONLESS,
-
     #[serde(rename = "farad")]
     FARAD,
-
     #[serde(rename = "gram")]
     GRAM,
-
     #[serde(rename = "gray")]
     GRAY,
-
     #[serde(rename = "henry")]
     HENRY,
-
     #[serde(rename = "hertz")]
     HERTZ,
-
     #[serde(rename = "item")]
     ITEM,
-
     #[serde(rename = "joule")]
     JOULE,
-
     #[serde(rename = "katal")]
     KATAL,
-
     #[serde(rename = "kelvin")]
     KELVIN,
-
     #[serde(rename = "kilogram")]
     KILOGRAM,
-
     #[serde(rename = "litre")]
     LITRE,
-
     #[serde(rename = "lumen")]
     LUMEN,
-
     #[serde(rename = "lux")]
     LUX,
-
     #[serde(rename = "metre")]
     METRE,
-
     #[serde(rename = "mole")]
     MOLE,
-
     #[serde(rename = "newton")]
     NEWTON,
-
     #[serde(rename = "ohm")]
     OHM,
-
     #[serde(rename = "pascal")]
     PASCAL,
-
     #[serde(rename = "radian")]
     RADIAN,
-
     #[serde(rename = "second")]
     SECOND,
-
     #[serde(rename = "siemens")]
     SIEMENS,
-
     #[serde(rename = "sievert")]
     SIEVERT,
-
     #[serde(rename = "steradian")]
     STERADIAN,
-
     #[serde(rename = "tesla")]
     TESLA,
-
     #[serde(rename = "volt")]
     VOLT,
-
     #[serde(rename = "watt")]
     WATT,
-
     #[serde(rename = "weber")]
     WEBER,
-
 }

--- a/enzymeml-ts/src/v2.ts
+++ b/enzymeml-ts/src/v2.ts
@@ -42,6 +42,10 @@ export const JsonLdSchema = z.object({
 });
 
 // EnzymeML Type definitions
+// This is the root object that composes all objects found in an EnzymeML
+// document. It also includes general metadata such as the name of
+// the document, when it was created/modified, and references to
+// publications, databases, and arbitrary links to the web.
 export const EnzymeMLDocumentSchema = z.lazy(() => JsonLdSchema.extend({
   name: z.string().describe(`
     Title of the EnzymeML Document.
@@ -49,6 +53,10 @@ export const EnzymeMLDocumentSchema = z.lazy(() => JsonLdSchema.extend({
   references: z.array(z.string()).describe(`
     Contains references to publications, databases, and arbitrary links to
     the web.
+  `),
+  description: z.string().nullable().describe(`
+    Free-text field for further desctiptions of the experiment and
+    dataset.
   `),
   created: z.string().nullable().describe(`
     Date the EnzymeML document was created.
@@ -88,6 +96,8 @@ export const EnzymeMLDocumentSchema = z.lazy(() => JsonLdSchema.extend({
 
 export type EnzymeMLDocument = z.infer<typeof EnzymeMLDocumentSchema>;
 
+// The creator object contains all information about authors that
+// contributed to the resulting document.
 export const CreatorSchema = z.lazy(() => JsonLdSchema.extend({
   given_name: z.string().describe(`
     Given name of the author or contributor.
@@ -102,6 +112,9 @@ export const CreatorSchema = z.lazy(() => JsonLdSchema.extend({
 
 export type Creator = z.infer<typeof CreatorSchema>;
 
+// This object describes vessels in which the experiment has been carried
+// out. These can include any type of vessel used in biocatalytic
+// experiments.
 export const VesselSchema = z.lazy(() => JsonLdSchema.extend({
   id: z.string().describe(`
     Unique identifier of the vessel.
@@ -122,6 +135,8 @@ export const VesselSchema = z.lazy(() => JsonLdSchema.extend({
 
 export type Vessel = z.infer<typeof VesselSchema>;
 
+// This object describes the proteins that were used or formed throughout
+// the experiment.
 export const ProteinSchema = z.lazy(() => JsonLdSchema.extend({
   id: z.string().describe(`
     Unique internal identifier of the protein.
@@ -151,6 +166,8 @@ export const ProteinSchema = z.lazy(() => JsonLdSchema.extend({
 
 export type Protein = z.infer<typeof ProteinSchema>;
 
+// This object describes complexes made of reactants and/or proteins that
+// were used or produced in the course of the experiment.
 export const ComplexSchema = z.lazy(() => JsonLdSchema.extend({
   id: z.string().describe(`
     Unique identifier of the complex.
@@ -167,12 +184,15 @@ export const ComplexSchema = z.lazy(() => JsonLdSchema.extend({
 
 export type Complex = z.infer<typeof ComplexSchema>;
 
+// This object describes the reactants that were used or produced in the
+// course of the experiment.
 export const SmallMoleculeSchema = z.lazy(() => JsonLdSchema.extend({
   id: z.string().describe(`
     Unique identifier of the small molecule.
   `),
   name: z.string(),
   constant: z.boolean(),
+  synonymous_names: z.array(z.string()),
   vessel_id: z.string().nullable().describe(`
     Unique identifier of the vessel this small molecule has been used in.
   `),
@@ -195,6 +215,9 @@ export const SmallMoleculeSchema = z.lazy(() => JsonLdSchema.extend({
 
 export type SmallMolecule = z.infer<typeof SmallMoleculeSchema>;
 
+// This object describes a chemical or enzymatic reaction that was
+// investigated in the course of the experiment. All species used
+// within this object need to be part of the data model.
 export const ReactionSchema = z.lazy(() => JsonLdSchema.extend({
   id: z.string().describe(`
     Unique identifier of the reaction.
@@ -219,6 +242,9 @@ export const ReactionSchema = z.lazy(() => JsonLdSchema.extend({
 
 export type Reaction = z.infer<typeof ReactionSchema>;
 
+// This object is part of the Reaction object and describes either an
+// educt, product or modifier. The latter includes buffers, counter-
+// ions as well as proteins/enzymes.
 export const ReactionElementSchema = z.lazy(() => JsonLdSchema.extend({
   species_id: z.string().describe(`
     Internal identifier to either a protein or reactant defined in the
@@ -231,6 +257,11 @@ export const ReactionElementSchema = z.lazy(() => JsonLdSchema.extend({
 
 export type ReactionElement = z.infer<typeof ReactionElementSchema>;
 
+// This object describes an equation that can be used to model the
+// kinetics of a reaction. There are different types of equations
+// that can be used to model the kinetics of a reaction. The equation
+// can be an ordinary differential equation, a rate law or assignment
+// rule.
 export const EquationSchema = z.lazy(() => JsonLdSchema.extend({
   equation: z.string().describe(`
     Mathematical expression of the equation.
@@ -249,6 +280,7 @@ export const EquationSchema = z.lazy(() => JsonLdSchema.extend({
 
 export type Equation = z.infer<typeof EquationSchema>;
 
+// This object describes a variable that is part of an equation.
 export const VariableSchema = z.lazy(() => JsonLdSchema.extend({
   id: z.string().describe(`
     Unique identifier of the variable.
@@ -263,6 +295,8 @@ export const VariableSchema = z.lazy(() => JsonLdSchema.extend({
 
 export type Variable = z.infer<typeof VariableSchema>;
 
+// This object describes the parameters of the kinetic model and can
+// include all estimated values.
 export const ParameterSchema = z.lazy(() => JsonLdSchema.extend({
   id: z.string().describe(`
     Unique identifier of the parameter.
@@ -298,6 +332,9 @@ export const ParameterSchema = z.lazy(() => JsonLdSchema.extend({
 
 export type Parameter = z.infer<typeof ParameterSchema>;
 
+// This object describes the result of a measurement, which includes time
+// course data of any type defined in DataTypes. It includes initial
+// concentrations of all species used in a single measurement.
 export const MeasurementSchema = z.lazy(() => JsonLdSchema.extend({
   id: z.string().describe(`
     Unique identifier of the measurement.
@@ -325,6 +362,9 @@ export const MeasurementSchema = z.lazy(() => JsonLdSchema.extend({
 
 export type Measurement = z.infer<typeof MeasurementSchema>;
 
+// This object describes a single entity of a measurement, which
+// corresponds to one species. It also holds replicates that contain
+// time course data.
 export const MeasurementDataSchema = z.lazy(() => JsonLdSchema.extend({
   species_id: z.string().describe(`
     The identifier for the described reactant.
@@ -361,6 +401,7 @@ export const MeasurementDataSchema = z.lazy(() => JsonLdSchema.extend({
 
 export type MeasurementData = z.infer<typeof MeasurementDataSchema>;
 
+// Represents a unit definition that is based on the SI unit system.
 export const UnitDefinitionSchema = z.lazy(() => JsonLdSchema.extend({
   id: z.string().nullable().describe(`
     Unique identifier of the unit definition.
@@ -375,6 +416,7 @@ export const UnitDefinitionSchema = z.lazy(() => JsonLdSchema.extend({
 
 export type UnitDefinition = z.infer<typeof UnitDefinitionSchema>;
 
+// Represents a base unit in the unit definition.
 export const BaseUnitSchema = z.lazy(() => JsonLdSchema.extend({
   kind: UnitTypeSchema.describe(`
     Kind of the base unit (e.g., meter, kilogram, second).

--- a/pyenzyme/v2.py
+++ b/pyenzyme/v2.py
@@ -29,11 +29,11 @@ WARNING: This is an auto-generated file.
 Do not edit directly - any changes will be overwritten.
 """
 
-
 ## This is a generated file. Do not modify it manually!
 
+
 from __future__ import annotations
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 from uuid import uuid4
 from datetime import date, datetime
 from xml.dom import minidom
@@ -41,102 +41,102 @@ from enum import Enum
 
 from lxml.etree import _Element
 from pydantic import PrivateAttr, model_validator
-from pydantic_xml import attr, element, BaseXmlModel
+from pydantic_xml import attr, wrapped, element, BaseXmlModel
 
 
 class EnzymeMLDocument(
     BaseXmlModel,
     search_mode="unordered",
 ):
+    """
+    This is the root object that composes all objects found in an EnzymeML document.
+    It also includes general metadata such as the name of the document, when
+    it was created/modified, and references to publications, databases, and
+    arbitrary links to the web.
+    """
     name: str = element(
-            tag="name",
-            description="""Title of the EnzymeML Document.""",
-            json_schema_extra=dict(term = "schema:title",)
-        )
-
+        tag="name",
+        description="""Title of the EnzymeML Document.""",
+        json_schema_extra=dict(term = "schema:title",),
+    )
     references: list[str] = element(
-            default_factory=list,
-            tag="references",
-            description="""Contains references to publications, databases, and arbitrary links to the web.""",
-            json_schema_extra=dict(term = "schema:citation",)
-        )
-
+        default_factory=list,
+        tag="references",
+        description="""Contains references to publications, databases, and arbitrary links to the web.""",
+        json_schema_extra=dict(term = "schema:citation",),
+    )
+    description: Optional[str] = element(
+        default=None,
+        tag="description",
+        description="""Free-text field for further desctiptions of the experiment and dataset.""",
+        json_schema_extra=dict(),
+    )
     created: Optional[str] = element(
-            default=None,
-            tag="created",
-            description="""Date the EnzymeML document was created.""",
-            json_schema_extra=dict(term = "schema:dateCreated",)
-        )
-
+        default=None,
+        tag="created",
+        description="""Date the EnzymeML document was created.""",
+        json_schema_extra=dict(term = "schema:dateCreated",),
+    )
     modified: Optional[str] = element(
-            default=None,
-            tag="modified",
-            description="""Date the EnzymeML document was modified.""",
-            json_schema_extra=dict(term = "schema:dateModified",)
-        )
-
+        default=None,
+        tag="modified",
+        description="""Date the EnzymeML document was modified.""",
+        json_schema_extra=dict(term = "schema:dateModified",),
+    )
     creators: list[Creator] = element(
-            default_factory=list,
-            tag="creators",
-            description="""Contains all authors that are part of the experiment.""",
-            json_schema_extra=dict(term = "schema:creator",)
-        )
-
+        default_factory=list,
+        tag="creators",
+        description="""Contains all authors that are part of the experiment.""",
+        json_schema_extra=dict(term = "schema:creator",),
+    )
     vessels: list[Vessel] = element(
-            default_factory=list,
-            tag="vessels",
-            description="""Contains all vessels that are part of the experiment.""",
-            json_schema_extra=dict()
-        )
-
+        default_factory=list,
+        tag="vessels",
+        description="""Contains all vessels that are part of the experiment.""",
+        json_schema_extra=dict(),
+    )
     proteins: list[Protein] = element(
-            default_factory=list,
-            tag="proteins",
-            description="""Contains all proteins that are part of the experiment.""",
-            json_schema_extra=dict()
-        )
-
+        default_factory=list,
+        tag="proteins",
+        description="""Contains all proteins that are part of the experiment.""",
+        json_schema_extra=dict(),
+    )
     complexes: list[Complex] = element(
-            default_factory=list,
-            tag="complexes",
-            description="""Contains all complexes that are part of the experiment.""",
-            json_schema_extra=dict()
-        )
-
+        default_factory=list,
+        tag="complexes",
+        description="""Contains all complexes that are part of the experiment.""",
+        json_schema_extra=dict(),
+    )
     small_molecules: list[SmallMolecule] = element(
-            default_factory=list,
-            tag="small_molecules",
-            description="""Contains all reactants that are part of the experiment.""",
-            json_schema_extra=dict()
-        )
-
+        default_factory=list,
+        tag="small_molecules",
+        description="""Contains all reactants that are part of the experiment.""",
+        json_schema_extra=dict(),
+    )
     reactions: list[Reaction] = element(
-            default_factory=list,
-            tag="reactions",
-            description="""Dictionary mapping from reaction IDs to reaction-describing objects.""",
-            json_schema_extra=dict()
-        )
-
+        default_factory=list,
+        tag="reactions",
+        description="""Dictionary mapping from reaction IDs to reaction-describing objects.""",
+        json_schema_extra=dict(),
+    )
     measurements: list[Measurement] = element(
-            default_factory=list,
-            tag="measurements",
-            description="""Contains measurements that describe outcomes of an experiment.""",
-            json_schema_extra=dict()
-        )
-
+        default_factory=list,
+        tag="measurements",
+        description="""Contains measurements that describe outcomes of an experiment.""",
+        json_schema_extra=dict(),
+    )
     equations: list[Equation] = element(
-            default_factory=list,
-            tag="equations",
-            description="""Contains ordinary differential equations that describe the kinetic model.""",
-            json_schema_extra=dict()
-        )
-
+        default_factory=list,
+        tag="equations",
+        description="""Contains ordinary differential equations that describe the kinetic model.""",
+        json_schema_extra=dict(),
+    )
     parameters: list[Parameter] = element(
-            default_factory=list,
-            tag="parameters",
-            description="""List of parameters that are part of the equation""",
-            json_schema_extra=dict()
-        )
+        default_factory=list,
+        tag="parameters",
+        description="""List of parameters that are part of the equation""",
+        json_schema_extra=dict(),
+    )
 
 
     def add_to_creators(
@@ -146,6 +146,7 @@ class EnzymeMLDocument(
         mail: str,
         **kwargs,
     ):
+        """Helper method to add a new Creator to the creators list."""
         params = {
             "given_name": given_name,
             "family_name": family_name,
@@ -157,15 +158,17 @@ class EnzymeMLDocument(
         )
 
         return self.creators[-1]
+
     def add_to_vessels(
         self,
         id: str,
         name: str,
         volume: float,
         unit: UnitDefinition,
-        constant: bool= True,
+        constant: bool=True,
         **kwargs,
     ):
+        """Helper method to add a new Vessel to the vessels list."""
         params = {
             "id": id,
             "name": name,
@@ -179,11 +182,12 @@ class EnzymeMLDocument(
         )
 
         return self.vessels[-1]
+
     def add_to_proteins(
         self,
         id: str,
         name: str,
-        constant: bool= False,
+        constant: bool=False,
         sequence: Optional[str]= None,
         vessel_id: Optional[str]= None,
         ecnumber: Optional[str]= None,
@@ -192,6 +196,7 @@ class EnzymeMLDocument(
         references: list[str]= [],
         **kwargs,
     ):
+        """Helper method to add a new Protein to the proteins list."""
         params = {
             "id": id,
             "name": name,
@@ -209,15 +214,17 @@ class EnzymeMLDocument(
         )
 
         return self.proteins[-1]
+
     def add_to_complexes(
         self,
         id: str,
         name: str,
-        constant: bool= False,
+        constant: bool=False,
         vessel_id: Optional[str]= None,
         participants: list[str]= [],
         **kwargs,
     ):
+        """Helper method to add a new Complex to the complexes list."""
         params = {
             "id": id,
             "name": name,
@@ -231,11 +238,13 @@ class EnzymeMLDocument(
         )
 
         return self.complexes[-1]
+
     def add_to_small_molecules(
         self,
         id: str,
         name: str,
-        constant: bool= False,
+        constant: bool=False,
+        synonymous_names: list[str]= [],
         vessel_id: Optional[str]= None,
         canonical_smiles: Optional[str]= None,
         inchi: Optional[str]= None,
@@ -243,10 +252,12 @@ class EnzymeMLDocument(
         references: list[str]= [],
         **kwargs,
     ):
+        """Helper method to add a new SmallMolecule to the small_molecules list."""
         params = {
             "id": id,
             "name": name,
             "constant": constant,
+            "synonymous_names": synonymous_names,
             "vessel_id": vessel_id,
             "canonical_smiles": canonical_smiles,
             "inchi": inchi,
@@ -259,16 +270,18 @@ class EnzymeMLDocument(
         )
 
         return self.small_molecules[-1]
+
     def add_to_reactions(
         self,
         id: str,
         name: str,
-        reversible: bool= False,
+        reversible: bool=False,
         kinetic_law: Optional[Equation]= None,
         species: list[ReactionElement]= [],
         modifiers: list[str]= [],
         **kwargs,
     ):
+        """Helper method to add a new Reaction to the reactions list."""
         params = {
             "id": id,
             "name": name,
@@ -283,6 +296,7 @@ class EnzymeMLDocument(
         )
 
         return self.reactions[-1]
+
     def add_to_measurements(
         self,
         id: str,
@@ -294,6 +308,7 @@ class EnzymeMLDocument(
         temperature_unit: Optional[UnitDefinition]= None,
         **kwargs,
     ):
+        """Helper method to add a new Measurement to the measurements list."""
         params = {
             "id": id,
             "name": name,
@@ -309,6 +324,7 @@ class EnzymeMLDocument(
         )
 
         return self.measurements[-1]
+
     def add_to_equations(
         self,
         equation: str,
@@ -317,6 +333,7 @@ class EnzymeMLDocument(
         variables: list[Variable]= [],
         **kwargs,
     ):
+        """Helper method to add a new Equation to the equations list."""
         params = {
             "equation": equation,
             "equation_type": equation_type,
@@ -329,6 +346,7 @@ class EnzymeMLDocument(
         )
 
         return self.equations[-1]
+
     def add_to_parameters(
         self,
         id: str,
@@ -340,9 +358,10 @@ class EnzymeMLDocument(
         upper: Optional[float]= None,
         lower: Optional[float]= None,
         stderr: Optional[float]= None,
-        constant: Optional[bool]= True,
+        constant: Optional[bool]=True,
         **kwargs,
     ):
+        """Helper method to add a new Parameter to the parameters list."""
         params = {
             "id": id,
             "name": name,
@@ -361,15 +380,16 @@ class EnzymeMLDocument(
         )
 
         return self.parameters[-1]
-
     def xml(self, encoding: str = "unicode") -> str | bytes:
         """Converts the object to an XML string
 
         Args:
             encoding (str, optional): The encoding to use. If set to "bytes", will return a bytes string.
                                       Defaults to "unicode".
-        """
 
+        Returns:
+            str | bytes: The XML representation of the object
+        """
         if encoding == "bytes":
             return self.to_xml()
 
@@ -382,23 +402,25 @@ class Creator(
     BaseXmlModel,
     search_mode="unordered",
 ):
+    """
+    The creator object contains all information about authors that contributed to
+    the resulting document.
+    """
     given_name: str = element(
-            tag="given_name",
-            description="""Given name of the author or contributor.""",
-            json_schema_extra=dict(term = "schema:givenName",)
-        )
-
+        tag="given_name",
+        description="""Given name of the author or contributor.""",
+        json_schema_extra=dict(term = "schema:givenName",),
+    )
     family_name: str = element(
-            tag="family_name",
-            description="""Family name of the author or contributor.""",
-            json_schema_extra=dict(term = "schema:familyName",)
-        )
-
+        tag="family_name",
+        description="""Family name of the author or contributor.""",
+        json_schema_extra=dict(term = "schema:familyName",),
+    )
     mail: str = element(
-            tag="mail",
-            description="""Email address of the author or contributor.""",
-            json_schema_extra=dict(term = "schema:email",)
-        )
+        tag="mail",
+        description="""Email address of the author or contributor.""",
+        json_schema_extra=dict(term = "schema:email",),
+    )
 
 
     def xml(self, encoding: str = "unicode") -> str | bytes:
@@ -407,8 +429,10 @@ class Creator(
         Args:
             encoding (str, optional): The encoding to use. If set to "bytes", will return a bytes string.
                                       Defaults to "unicode".
-        """
 
+        Returns:
+            str | bytes: The XML representation of the object
+        """
         if encoding == "bytes":
             return self.to_xml()
 
@@ -421,35 +445,35 @@ class Vessel(
     BaseXmlModel,
     search_mode="unordered",
 ):
+    """
+    This object describes vessels in which the experiment has been carried out.
+    These can include any type of vessel used in biocatalytic experiments.
+    """
     id: str = element(
-            tag="id",
-            description="""Unique identifier of the vessel.""",
-            json_schema_extra=dict(term = "schema:identifier",)
-        )
-
+        tag="id",
+        description="""Unique identifier of the vessel.""",
+        json_schema_extra=dict(term = "schema:identifier",),
+    )
     name: str = element(
-            tag="name",
-            description="""Name of the used vessel.""",
-            json_schema_extra=dict(term = "schema:name",)
-        )
-
+        tag="name",
+        description="""Name of the used vessel.""",
+        json_schema_extra=dict(term = "schema:name",),
+    )
     volume: float = element(
-            tag="volume",
-            description="""Volumetric value of the vessel.""",
-            json_schema_extra=dict(term = "OBO:OBI_0002139",)
-        )
-
+        tag="volume",
+        description="""Volumetric value of the vessel.""",
+        json_schema_extra=dict(term = "OBO:OBI_0002139",),
+    )
     unit: UnitDefinition = element(
-            tag="unit",
-            description="""Volumetric unit of the vessel.""",
-            json_schema_extra=dict()
-        )
-
+        tag="unit",
+        description="""Volumetric unit of the vessel.""",
+        json_schema_extra=dict(),
+    )
     constant: bool = element(
-            tag="constant",
-            description="""Whether the volume of the vessel is constant or not.""",
-            json_schema_extra=dict()
-        )
+        tag="constant",
+        description="""Whether the volume of the vessel is constant or not.""",
+        json_schema_extra=dict(),
+    )
 
 
     def xml(self, encoding: str = "unicode") -> str | bytes:
@@ -458,8 +482,10 @@ class Vessel(
         Args:
             encoding (str, optional): The encoding to use. If set to "bytes", will return a bytes string.
                                       Defaults to "unicode".
-        """
 
+        Returns:
+            str | bytes: The XML representation of the object
+        """
         if encoding == "bytes":
             return self.to_xml()
 
@@ -472,64 +498,60 @@ class Protein(
     BaseXmlModel,
     search_mode="unordered",
 ):
+    """
+    This object describes the proteins that were used or formed throughout the
+    experiment.
+    """
     id: str = element(
-            tag="id",
-            description="""Unique internal identifier of the protein.""",
-            json_schema_extra=dict(schema = "identifier",)
-        )
-
+        tag="id",
+        description="""Unique internal identifier of the protein.""",
+        json_schema_extra=dict(schema = "identifier",),
+    )
     name: str = element(
-            tag="name",
-            json_schema_extra=dict(term = "schema:name",)
-        )
-
+        tag="name",
+        json_schema_extra=dict(term = "schema:name",),
+    )
     constant: bool = element(
-            tag="constant",
-            json_schema_extra=dict()
-        )
-
+        tag="constant",
+        json_schema_extra=dict(),
+    )
     sequence: Optional[str] = element(
-            default=None,
-            tag="sequence",
-            description="""Amino acid sequence of the protein""",
-            json_schema_extra=dict(term = "OBO:GSSO_007262",)
-        )
-
+        default=None,
+        tag="sequence",
+        description="""Amino acid sequence of the protein""",
+        json_schema_extra=dict(term = "OBO:GSSO_007262",),
+    )
     vessel_id: Optional[str] = element(
-            default=None,
-            tag="vessel_id",
-            description="""Unique identifier of the vessel this protein has been used in.""",
-            json_schema_extra=dict(term = "schema:identifier",)
-        )
-
+        default=None,
+        tag="vessel_id",
+        description="""Unique identifier of the vessel this protein has been used in.""",
+        json_schema_extra=dict(term = "schema:identifier",),
+    )
     ecnumber: Optional[str] = element(
-            default=None,
-            tag="ecnumber",
-            description="""EC number of the protein.""",
-            json_schema_extra=dict()
-        )
-
+        default=None,
+        tag="ecnumber",
+        description="""EC number of the protein.""",
+        json_schema_extra=dict(),
+    )
     organism: Optional[str] = element(
-            default=None,
-            tag="organism",
-            description="""Organism the protein was expressed in.""",
-            json_schema_extra=dict(term = "OBO:OBI_0100026",)
-        )
-
+        default=None,
+        tag="organism",
+        description="""Organism the protein was expressed in.""",
+        json_schema_extra=dict(term = "OBO:OBI_0100026",),
+    )
     organism_tax_id: Optional[str] = element(
-            default=None,
-            tag="organism_tax_id",
-            description="""Taxonomy identifier of the expression host.""",
-            json_schema_extra=dict()
-        )
-
+        default=None,
+        tag="organism_tax_id",
+        description="""Taxonomy identifier of the expression host.""",
+        json_schema_extra=dict(),
+    )
     references: list[str] = element(
-            default_factory=list,
-            tag="references",
-            description="""Array of references to publications, database entries, etc. that describe the
+        default_factory=list,
+        tag="references",
+        description="""Array of references to publications, database entries, etc. that describe the
             protein.""",
-            json_schema_extra=dict(term = "schema:citation",)
-        )
+        json_schema_extra=dict(term = "schema:citation",),
+    )
 
 
     def xml(self, encoding: str = "unicode") -> str | bytes:
@@ -538,8 +560,10 @@ class Protein(
         Args:
             encoding (str, optional): The encoding to use. If set to "bytes", will return a bytes string.
                                       Defaults to "unicode".
-        """
 
+        Returns:
+            str | bytes: The XML representation of the object
+        """
         if encoding == "bytes":
             return self.to_xml()
 
@@ -552,35 +576,35 @@ class Complex(
     BaseXmlModel,
     search_mode="unordered",
 ):
+    """
+    This object describes complexes made of reactants and/or proteins that were used
+    or produced in the course of the experiment.
+    """
     id: str = element(
-            tag="id",
-            description="""Unique identifier of the complex.""",
-            json_schema_extra=dict(term = "schema:identifier",)
-        )
-
+        tag="id",
+        description="""Unique identifier of the complex.""",
+        json_schema_extra=dict(term = "schema:identifier",),
+    )
     name: str = element(
-            tag="name",
-            json_schema_extra=dict(term = "schema:name",)
-        )
-
+        tag="name",
+        json_schema_extra=dict(term = "schema:name",),
+    )
     constant: bool = element(
-            tag="constant",
-            json_schema_extra=dict()
-        )
-
+        tag="constant",
+        json_schema_extra=dict(),
+    )
     vessel_id: Optional[str] = element(
-            default=None,
-            tag="vessel_id",
-            description="""Unique identifier of the vessel this complex has been used in.""",
-            json_schema_extra=dict(term = "schema:identifier",)
-        )
-
+        default=None,
+        tag="vessel_id",
+        description="""Unique identifier of the vessel this complex has been used in.""",
+        json_schema_extra=dict(term = "schema:identifier",),
+    )
     participants: list[str] = element(
-            default_factory=list,
-            tag="participants",
-            description="""Array of IDs the complex contains""",
-            json_schema_extra=dict()
-        )
+        default_factory=list,
+        tag="participants",
+        description="""Array of IDs the complex contains""",
+        json_schema_extra=dict(),
+    )
 
 
     def xml(self, encoding: str = "unicode") -> str | bytes:
@@ -589,8 +613,10 @@ class Complex(
         Args:
             encoding (str, optional): The encoding to use. If set to "bytes", will return a bytes string.
                                       Defaults to "unicode".
-        """
 
+        Returns:
+            str | bytes: The XML representation of the object
+        """
         if encoding == "bytes":
             return self.to_xml()
 
@@ -603,58 +629,60 @@ class SmallMolecule(
     BaseXmlModel,
     search_mode="unordered",
 ):
+    """
+    This object describes the reactants that were used or produced in the course of
+    the experiment.
+    """
     id: str = element(
-            tag="id",
-            description="""Unique identifier of the small molecule.""",
-            json_schema_extra=dict(term = "schema:identifier",)
-        )
-
+        tag="id",
+        description="""Unique identifier of the small molecule.""",
+        json_schema_extra=dict(term = "schema:identifier",),
+    )
     name: str = element(
-            tag="name",
-            json_schema_extra=dict(term = "schema:name",)
-        )
-
+        tag="name",
+        json_schema_extra=dict(term = "schema:name",),
+    )
     constant: bool = element(
-            tag="constant",
-            json_schema_extra=dict()
-        )
-
+        tag="constant",
+        json_schema_extra=dict(),
+    )
+    synonymous_names: list[str] = element(
+        default_factory=list,
+        tag="synonymous_names",
+        json_schema_extra=dict(),
+    )
     vessel_id: Optional[str] = element(
-            default=None,
-            tag="vessel_id",
-            description="""Unique identifier of the vessel this small molecule has been used in.""",
-            json_schema_extra=dict(term = "schema:identifier",)
-        )
-
+        default=None,
+        tag="vessel_id",
+        description="""Unique identifier of the vessel this small molecule has been used in.""",
+        json_schema_extra=dict(term = "schema:identifier",),
+    )
     canonical_smiles: Optional[str] = element(
-            default=None,
-            tag="canonical_smiles",
-            description="""Canonical Simplified Molecular-Input Line-Entry System (SMILES) encoding of
+        default=None,
+        tag="canonical_smiles",
+        description="""Canonical Simplified Molecular-Input Line-Entry System (SMILES) encoding of
             the reactant.""",
-            json_schema_extra=dict()
-        )
-
+        json_schema_extra=dict(),
+    )
     inchi: Optional[str] = element(
-            default=None,
-            tag="inchi",
-            description="""International Chemical Identifier (InChI) encoding of the reactant.""",
-            json_schema_extra=dict()
-        )
-
+        default=None,
+        tag="inchi",
+        description="""International Chemical Identifier (InChI) encoding of the reactant.""",
+        json_schema_extra=dict(),
+    )
     inchikey: Optional[str] = element(
-            default=None,
-            tag="inchikey",
-            description="""Hashed International Chemical Identifier (InChIKey) encoding of the reactant.""",
-            json_schema_extra=dict()
-        )
-
+        default=None,
+        tag="inchikey",
+        description="""Hashed International Chemical Identifier (InChIKey) encoding of the reactant.""",
+        json_schema_extra=dict(),
+    )
     references: list[str] = element(
-            default_factory=list,
-            tag="references",
-            description="""Array of references to publications, database entries, etc. that describe the
+        default_factory=list,
+        tag="references",
+        description="""Array of references to publications, database entries, etc. that describe the
             reactant.""",
-            json_schema_extra=dict(term = "schema:citation",)
-        )
+        json_schema_extra=dict(term = "schema:citation",),
+    )
 
 
     def xml(self, encoding: str = "unicode") -> str | bytes:
@@ -663,8 +691,10 @@ class SmallMolecule(
         Args:
             encoding (str, optional): The encoding to use. If set to "bytes", will return a bytes string.
                                       Defaults to "unicode".
-        """
 
+        Returns:
+            str | bytes: The XML representation of the object
+        """
         if encoding == "bytes":
             return self.to_xml()
 
@@ -677,44 +707,44 @@ class Reaction(
     BaseXmlModel,
     search_mode="unordered",
 ):
+    """
+    This object describes a chemical or enzymatic reaction that was investigated in
+    the course of the experiment. All species used within this object need to be
+    part of the data model.
+    """
     id: str = element(
-            tag="id",
-            description="""Unique identifier of the reaction.""",
-            json_schema_extra=dict(term = "schema:identifier",)
-        )
-
+        tag="id",
+        description="""Unique identifier of the reaction.""",
+        json_schema_extra=dict(term = "schema:identifier",),
+    )
     name: str = element(
-            tag="name",
-            description="""Name of the reaction.""",
-            json_schema_extra=dict()
-        )
-
+        tag="name",
+        description="""Name of the reaction.""",
+        json_schema_extra=dict(),
+    )
     reversible: bool = element(
-            tag="reversible",
-            description="""Whether the reaction is reversible or irreversible""",
-            json_schema_extra=dict()
-        )
-
+        tag="reversible",
+        description="""Whether the reaction is reversible or irreversible""",
+        json_schema_extra=dict(),
+    )
     kinetic_law: Optional[Equation] = element(
-            default=None,
-            tag="kinetic_law",
-            description="""Mathematical expression of the reaction.""",
-            json_schema_extra=dict()
-        )
-
+        default=None,
+        tag="kinetic_law",
+        description="""Mathematical expression of the reaction.""",
+        json_schema_extra=dict(),
+    )
     species: list[ReactionElement] = element(
-            default_factory=list,
-            tag="species",
-            description="""List of reaction elements that are part of the reaction.""",
-            json_schema_extra=dict()
-        )
-
+        default_factory=list,
+        tag="species",
+        description="""List of reaction elements that are part of the reaction.""",
+        json_schema_extra=dict(),
+    )
     modifiers: list[str] = element(
-            default_factory=list,
-            tag="modifiers",
-            description="""List of reaction elements that are not part of the reaction but influence it.""",
-            json_schema_extra=dict()
-        )
+        default_factory=list,
+        tag="modifiers",
+        description="""List of reaction elements that are not part of the reaction but influence it.""",
+        json_schema_extra=dict(),
+    )
 
 
     def add_to_species(
@@ -723,6 +753,7 @@ class Reaction(
         stoichiometry: float,
         **kwargs,
     ):
+        """Helper method to add a new ReactionElement to the species list."""
         params = {
             "species_id": species_id,
             "stoichiometry": stoichiometry
@@ -733,15 +764,16 @@ class Reaction(
         )
 
         return self.species[-1]
-
     def xml(self, encoding: str = "unicode") -> str | bytes:
         """Converts the object to an XML string
 
         Args:
             encoding (str, optional): The encoding to use. If set to "bytes", will return a bytes string.
                                       Defaults to "unicode".
-        """
 
+        Returns:
+            str | bytes: The XML representation of the object
+        """
         if encoding == "bytes":
             return self.to_xml()
 
@@ -754,18 +786,22 @@ class ReactionElement(
     BaseXmlModel,
     search_mode="unordered",
 ):
+    """
+    This object is part of the Reaction object and describes either an educt,
+    product or modifier. The latter includes buffers, counter-ions as well as
+    proteins/enzymes.
+    """
     species_id: str = element(
-            tag="species_id",
-            description="""Internal identifier to either a protein or reactant defined in the
+        tag="species_id",
+        description="""Internal identifier to either a protein or reactant defined in the
             EnzymeMLDocument.""",
-            json_schema_extra=dict(schema = "identifier",)
-        )
-
+        json_schema_extra=dict(schema = "identifier",),
+    )
     stoichiometry: float = element(
-            tag="stoichiometry",
-            description="""Float number representing the associated stoichiometry.""",
-            json_schema_extra=dict()
-        )
+        tag="stoichiometry",
+        description="""Float number representing the associated stoichiometry.""",
+        json_schema_extra=dict(),
+    )
 
 
     def xml(self, encoding: str = "unicode") -> str | bytes:
@@ -774,8 +810,10 @@ class ReactionElement(
         Args:
             encoding (str, optional): The encoding to use. If set to "bytes", will return a bytes string.
                                       Defaults to "unicode".
-        """
 
+        Returns:
+            str | bytes: The XML representation of the object
+        """
         if encoding == "bytes":
             return self.to_xml()
 
@@ -788,32 +826,35 @@ class Equation(
     BaseXmlModel,
     search_mode="unordered",
 ):
+    """
+    This object describes an equation that can be used to model the kinetics of a
+    reaction. There are different types of equations that can be used to model
+    the kinetics of a reaction. The equation can be an ordinary differential
+    equation, a rate law or assignment rule.
+    """
     equation: str = element(
-            tag="equation",
-            description="""Mathematical expression of the equation.""",
-            json_schema_extra=dict()
-        )
-
+        tag="equation",
+        description="""Mathematical expression of the equation.""",
+        json_schema_extra=dict(),
+    )
     equation_type: EquationType = element(
-            tag="equation_type",
-            description="""Type of the equation.""",
-            json_schema_extra=dict()
-        )
-
+        tag="equation_type",
+        description="""Type of the equation.""",
+        json_schema_extra=dict(),
+    )
     species_id: Optional[str] = element(
-            default=None,
-            tag="species_id",
-            description="""Internal identifier to a species defined in the EnzymeMLDocument, given it is a
+        default=None,
+        tag="species_id",
+        description="""Internal identifier to a species defined in the EnzymeMLDocument, given it is a
             rate equation.""",
-            json_schema_extra=dict()
-        )
-
+        json_schema_extra=dict(),
+    )
     variables: list[Variable] = element(
-            default_factory=list,
-            tag="variables",
-            description="""List of variables that are part of the equation""",
-            json_schema_extra=dict()
-        )
+        default_factory=list,
+        tag="variables",
+        description="""List of variables that are part of the equation""",
+        json_schema_extra=dict(),
+    )
 
 
     def add_to_variables(
@@ -823,6 +864,7 @@ class Equation(
         symbol: str,
         **kwargs,
     ):
+        """Helper method to add a new Variable to the variables list."""
         params = {
             "id": id,
             "name": name,
@@ -834,15 +876,16 @@ class Equation(
         )
 
         return self.variables[-1]
-
     def xml(self, encoding: str = "unicode") -> str | bytes:
         """Converts the object to an XML string
 
         Args:
             encoding (str, optional): The encoding to use. If set to "bytes", will return a bytes string.
                                       Defaults to "unicode".
-        """
 
+        Returns:
+            str | bytes: The XML representation of the object
+        """
         if encoding == "bytes":
             return self.to_xml()
 
@@ -855,23 +898,24 @@ class Variable(
     BaseXmlModel,
     search_mode="unordered",
 ):
+    """
+    This object describes a variable that is part of an equation.
+    """
     id: str = element(
-            tag="id",
-            description="""Unique identifier of the variable.""",
-            json_schema_extra=dict(term = "schema:identifier",)
-        )
-
+        tag="id",
+        description="""Unique identifier of the variable.""",
+        json_schema_extra=dict(term = "schema:identifier",),
+    )
     name: str = element(
-            tag="name",
-            description="""Name of the variable.""",
-            json_schema_extra=dict()
-        )
-
+        tag="name",
+        description="""Name of the variable.""",
+        json_schema_extra=dict(),
+    )
     symbol: str = element(
-            tag="symbol",
-            description="""Symbol of the variable.""",
-            json_schema_extra=dict()
-        )
+        tag="symbol",
+        description="""Symbol of the variable.""",
+        json_schema_extra=dict(),
+    )
 
 
     def xml(self, encoding: str = "unicode") -> str | bytes:
@@ -880,8 +924,10 @@ class Variable(
         Args:
             encoding (str, optional): The encoding to use. If set to "bytes", will return a bytes string.
                                       Defaults to "unicode".
-        """
 
+        Returns:
+            str | bytes: The XML representation of the object
+        """
         if encoding == "bytes":
             return self.to_xml()
 
@@ -894,72 +940,67 @@ class Parameter(
     BaseXmlModel,
     search_mode="unordered",
 ):
+    """
+    This object describes the parameters of the kinetic model and can include all
+    estimated values.
+    """
     id: str = element(
-            tag="id",
-            description="""Unique identifier of the parameter.""",
-            json_schema_extra=dict(term = "schema:identifier",)
-        )
-
+        tag="id",
+        description="""Unique identifier of the parameter.""",
+        json_schema_extra=dict(term = "schema:identifier",),
+    )
     name: str = element(
-            tag="name",
-            description="""Name of the parameter.""",
-            json_schema_extra=dict()
-        )
-
+        tag="name",
+        description="""Name of the parameter.""",
+        json_schema_extra=dict(),
+    )
     symbol: str = element(
-            tag="symbol",
-            description="""Symbol of the parameter.""",
-            json_schema_extra=dict()
-        )
-
+        tag="symbol",
+        description="""Symbol of the parameter.""",
+        json_schema_extra=dict(),
+    )
     value: Optional[float] = element(
-            default=None,
-            tag="value",
-            description="""Numerical value of the estimated parameter.""",
-            json_schema_extra=dict()
-        )
-
+        default=None,
+        tag="value",
+        description="""Numerical value of the estimated parameter.""",
+        json_schema_extra=dict(),
+    )
     unit: Optional[UnitDefinition] = element(
-            default=None,
-            tag="unit",
-            description="""Unit of the estimated parameter.""",
-            json_schema_extra=dict()
-        )
-
+        default=None,
+        tag="unit",
+        description="""Unit of the estimated parameter.""",
+        json_schema_extra=dict(),
+    )
     initial_value: Optional[float] = element(
-            default=None,
-            tag="initial_value",
-            description="""Initial value that was used for the parameter estimation.""",
-            json_schema_extra=dict()
-        )
-
+        default=None,
+        tag="initial_value",
+        description="""Initial value that was used for the parameter estimation.""",
+        json_schema_extra=dict(),
+    )
     upper: Optional[float] = element(
-            default=None,
-            tag="upper",
-            description="""Upper bound of the estimated parameter.""",
-            json_schema_extra=dict()
-        )
-
+        default=None,
+        tag="upper",
+        description="""Upper bound of the estimated parameter.""",
+        json_schema_extra=dict(),
+    )
     lower: Optional[float] = element(
-            default=None,
-            tag="lower",
-            description="""Lower bound of the estimated parameter.""",
-            json_schema_extra=dict()
-        )
-
+        default=None,
+        tag="lower",
+        description="""Lower bound of the estimated parameter.""",
+        json_schema_extra=dict(),
+    )
     stderr: Optional[float] = element(
-            default=None,
-            tag="stderr",
-            description="""Standard error of the estimated parameter.""",
-            json_schema_extra=dict()
-        )
-
+        default=None,
+        tag="stderr",
+        description="""Standard error of the estimated parameter.""",
+        json_schema_extra=dict(),
+    )
     constant: Optional[bool] = element(
-            default=true,
-            tag="constant",
-            description="""Specifies if this parameter is constant""",
-            json_schema_extra=dict()
-        )
+        default=True,
+        tag="constant",
+        description="""Specifies if this parameter is constant""",
+        json_schema_extra=dict(),
+    )
 
 
     def xml(self, encoding: str = "unicode") -> str | bytes:
@@ -968,8 +1009,10 @@ class Parameter(
         Args:
             encoding (str, optional): The encoding to use. If set to "bytes", will return a bytes string.
                                       Defaults to "unicode".
-        """
 
+        Returns:
+            str | bytes: The XML representation of the object
+        """
         if encoding == "bytes":
             return self.to_xml()
 
@@ -982,53 +1025,52 @@ class Measurement(
     BaseXmlModel,
     search_mode="unordered",
 ):
+    """
+    This object describes the result of a measurement, which includes time course
+    data of any type defined in DataTypes. It includes initial concentrations of
+    all species used in a single measurement.
+    """
     id: str = element(
-            tag="id",
-            description="""Unique identifier of the measurement.""",
-            json_schema_extra=dict(term = "schema:identifier",)
-        )
-
+        tag="id",
+        description="""Unique identifier of the measurement.""",
+        json_schema_extra=dict(term = "schema:identifier",),
+    )
     name: str = element(
-            tag="name",
-            description="""Name of the measurement""",
-            json_schema_extra=dict()
-        )
-
+        tag="name",
+        description="""Name of the measurement""",
+        json_schema_extra=dict(),
+    )
     species_data: list[MeasurementData] = element(
-            default_factory=list,
-            tag="species_data",
-            description="""Measurement data of all species that were part of the measurement. A species can
+        default_factory=list,
+        tag="species_data",
+        description="""Measurement data of all species that were part of the measurement. A species can
             refer to a protein, complex, or small molecule.""",
-            json_schema_extra=dict()
-        )
-
+        json_schema_extra=dict(),
+    )
     group_id: Optional[str] = element(
-            default=None,
-            tag="group_id",
-            description="""User-defined group ID to signal relationships between measurements.""",
-            json_schema_extra=dict()
-        )
-
+        default=None,
+        tag="group_id",
+        description="""User-defined group ID to signal relationships between measurements.""",
+        json_schema_extra=dict(),
+    )
     ph: Optional[float] = element(
-            default=None,
-            tag="ph",
-            description="""PH value of the measurement.""",
-            json_schema_extra=dict(minimum = "0",maximum = "14",)
-        )
-
+        default=None,
+        tag="ph",
+        description="""PH value of the measurement.""",
+        json_schema_extra=dict(minimum = "0",maximum = "14",),
+    )
     temperature: Optional[float] = element(
-            default=None,
-            tag="temperature",
-            description="""Temperature of the measurement.""",
-            json_schema_extra=dict()
-        )
-
+        default=None,
+        tag="temperature",
+        description="""Temperature of the measurement.""",
+        json_schema_extra=dict(),
+    )
     temperature_unit: Optional[UnitDefinition] = element(
-            default=None,
-            tag="temperature_unit",
-            description="""Unit of the temperature of the measurement.""",
-            json_schema_extra=dict()
-        )
+        default=None,
+        tag="temperature_unit",
+        description="""Unit of the temperature of the measurement.""",
+        json_schema_extra=dict(),
+    )
 
 
     def add_to_species_data(
@@ -1041,9 +1083,10 @@ class Measurement(
         data: list[float]= [],
         time: list[float]= [],
         time_unit: Optional[UnitDefinition]= None,
-        is_simulated: bool= False,
+        is_simulated: bool=False,
         **kwargs,
     ):
+        """Helper method to add a new MeasurementData to the species_data list."""
         params = {
             "species_id": species_id,
             "initial": initial,
@@ -1061,15 +1104,16 @@ class Measurement(
         )
 
         return self.species_data[-1]
-
     def xml(self, encoding: str = "unicode") -> str | bytes:
         """Converts the object to an XML string
 
         Args:
             encoding (str, optional): The encoding to use. If set to "bytes", will return a bytes string.
                                       Defaults to "unicode".
-        """
 
+        Returns:
+            str | bytes: The XML representation of the object
+        """
         if encoding == "bytes":
             return self.to_xml()
 
@@ -1082,67 +1126,63 @@ class MeasurementData(
     BaseXmlModel,
     search_mode="unordered",
 ):
+    """
+    This object describes a single entity of a measurement, which corresponds to one
+    species. It also holds replicates that contain time course data.
+    """
     species_id: str = element(
-            tag="species_id",
-            description="""The identifier for the described reactant.""",
-            json_schema_extra=dict()
-        )
-
+        tag="species_id",
+        description="""The identifier for the described reactant.""",
+        json_schema_extra=dict(),
+    )
     initial: float = element(
-            tag="initial",
-            description="""Initial amount of the measurement data. This must be the same as the first data
+        tag="initial",
+        description="""Initial amount of the measurement data. This must be the same as the first data
             point in the array.""",
-            json_schema_extra=dict()
-        )
-
+        json_schema_extra=dict(),
+    )
     data_unit: UnitDefinition = element(
-            tag="data_unit",
-            description="""SI unit of the data that was measured.""",
-            json_schema_extra=dict()
-        )
-
+        tag="data_unit",
+        description="""SI unit of the data that was measured.""",
+        json_schema_extra=dict(),
+    )
     data_type: DataTypes = element(
-            tag="data_type",
-            description="""Type of data that was measured (e.g. concentration)""",
-            json_schema_extra=dict()
-        )
-
+        tag="data_type",
+        description="""Type of data that was measured (e.g. concentration)""",
+        json_schema_extra=dict(),
+    )
     prepared: Optional[float] = element(
-            default=None,
-            tag="prepared",
-            description="""Amount of the reactant before the measurement. This field should be used for
+        default=None,
+        tag="prepared",
+        description="""Amount of the reactant before the measurement. This field should be used for
             specifying the prepared amount of a species in the reaction mix. Not
             to be confused with , specifying the concentration at the first data
             point from the array.""",
-            json_schema_extra=dict()
-        )
-
+        json_schema_extra=dict(),
+    )
     data: list[float] = element(
-            default_factory=list,
-            tag="data",
-            description="""Data that was measured.""",
-            json_schema_extra=dict()
-        )
-
+        default_factory=list,
+        tag="data",
+        description="""Data that was measured.""",
+        json_schema_extra=dict(),
+    )
     time: list[float] = element(
-            default_factory=list,
-            tag="time",
-            description="""Time steps of the replicate.""",
-            json_schema_extra=dict()
-        )
-
+        default_factory=list,
+        tag="time",
+        description="""Time steps of the replicate.""",
+        json_schema_extra=dict(),
+    )
     time_unit: Optional[UnitDefinition] = element(
-            default=None,
-            tag="time_unit",
-            description="""Time unit of the replicate.""",
-            json_schema_extra=dict()
-        )
-
+        default=None,
+        tag="time_unit",
+        description="""Time unit of the replicate.""",
+        json_schema_extra=dict(),
+    )
     is_simulated: bool = element(
-            tag="is_simulated",
-            description="""Whether or not the data has been generated by simulation.""",
-            json_schema_extra=dict()
-        )
+        tag="is_simulated",
+        description="""Whether or not the data has been generated by simulation.""",
+        json_schema_extra=dict(),
+    )
 
 
     def xml(self, encoding: str = "unicode") -> str | bytes:
@@ -1151,8 +1191,10 @@ class MeasurementData(
         Args:
             encoding (str, optional): The encoding to use. If set to "bytes", will return a bytes string.
                                       Defaults to "unicode".
-        """
 
+        Returns:
+            str | bytes: The XML representation of the object
+        """
         if encoding == "bytes":
             return self.to_xml()
 
@@ -1165,26 +1207,27 @@ class UnitDefinition(
     BaseXmlModel,
     search_mode="unordered",
 ):
+    """
+    Represents a unit definition that is based on the SI unit system.
+    """
     id: Optional[str] = attr(
-            default=None,
-            tag="id",
-            description="""Unique identifier of the unit definition.""",
-            json_schema_extra=dict()
-        )
-
+        default=None,
+        tag="id",
+        description="""Unique identifier of the unit definition.""",
+        json_schema_extra=dict(),
+    )
     name: Optional[str] = attr(
-            default=None,
-            tag="name",
-            description="""Common name of the unit definition.""",
-            json_schema_extra=dict()
-        )
-
+        default=None,
+        tag="name",
+        description="""Common name of the unit definition.""",
+        json_schema_extra=dict(),
+    )
     base_units: list[BaseUnit] = element(
-            default_factory=list,
-            tag="base_units",
-            description="""Base units that define the unit.""",
-            json_schema_extra=dict()
-        )
+        default_factory=list,
+        tag="base_units",
+        description="""Base units that define the unit.""",
+        json_schema_extra=dict(),
+    )
 
 
     def add_to_base_units(
@@ -1195,6 +1238,7 @@ class UnitDefinition(
         scale: Optional[float]= None,
         **kwargs,
     ):
+        """Helper method to add a new BaseUnit to the base_units list."""
         params = {
             "kind": kind,
             "exponent": exponent,
@@ -1207,15 +1251,16 @@ class UnitDefinition(
         )
 
         return self.base_units[-1]
-
     def xml(self, encoding: str = "unicode") -> str | bytes:
         """Converts the object to an XML string
 
         Args:
             encoding (str, optional): The encoding to use. If set to "bytes", will return a bytes string.
                                       Defaults to "unicode".
-        """
 
+        Returns:
+            str | bytes: The XML representation of the object
+        """
         if encoding == "bytes":
             return self.to_xml()
 
@@ -1228,31 +1273,31 @@ class BaseUnit(
     BaseXmlModel,
     search_mode="unordered",
 ):
+    """
+    Represents a base unit in the unit definition.
+    """
     kind: UnitType = attr(
-            tag="kind",
-            description="""Kind of the base unit (e.g., meter, kilogram, second).""",
-            json_schema_extra=dict()
-        )
-
+        tag="kind",
+        description="""Kind of the base unit (e.g., meter, kilogram, second).""",
+        json_schema_extra=dict(),
+    )
     exponent: int = attr(
-            tag="exponent",
-            description="""Exponent of the base unit in the unit definition.""",
-            json_schema_extra=dict()
-        )
-
+        tag="exponent",
+        description="""Exponent of the base unit in the unit definition.""",
+        json_schema_extra=dict(),
+    )
     multiplier: Optional[float] = attr(
-            default=None,
-            tag="multiplier",
-            description="""Multiplier of the base unit in the unit definition.""",
-            json_schema_extra=dict()
-        )
-
+        default=None,
+        tag="multiplier",
+        description="""Multiplier of the base unit in the unit definition.""",
+        json_schema_extra=dict(),
+    )
     scale: Optional[float] = attr(
-            default=None,
-            tag="scale",
-            description="""Scale of the base unit in the unit definition.""",
-            json_schema_extra=dict()
-        )
+        default=None,
+        tag="scale",
+        description="""Scale of the base unit in the unit definition.""",
+        json_schema_extra=dict(),
+    )
 
 
     def xml(self, encoding: str = "unicode") -> str | bytes:
@@ -1261,8 +1306,10 @@ class BaseUnit(
         Args:
             encoding (str, optional): The encoding to use. If set to "bytes", will return a bytes string.
                                       Defaults to "unicode".
-        """
 
+        Returns:
+            str | bytes: The XML representation of the object
+        """
         if encoding == "bytes":
             return self.to_xml()
 
@@ -1272,12 +1319,14 @@ class BaseUnit(
 
 
 class EquationType(Enum):
+    """Enumeration for EquationType values"""
     ASSIGNMENT = "assignment"
     INITIAL_ASSIGNMENT = "initialAssignment"
     ODE = "ode"
     RATE_LAW = "rateLaw"
 
 class DataTypes(Enum):
+    """Enumeration for DataTypes values"""
     ABSORBANCE = "http://purl.allotrope.org/ontologies/quality#AFQ_0000061"
     CONCENTRATION = "http://purl.obolibrary.org/obo/PATO_0000033"
     CONVERSION = "http://purl.allotrope.org/ontologies/quality#AFQ_0000226"
@@ -1286,6 +1335,7 @@ class DataTypes(Enum):
     TRANSMITTANCE = "http://purl.allotrope.org/ontologies/result#AFR_0002261"
 
 class UnitType(Enum):
+    """Enumeration for UnitType values"""
     AMPERE = "ampere"
     AVOGADRO = "avogadro"
     BECQUEREL = "becquerel"
@@ -1320,3 +1370,24 @@ class UnitType(Enum):
     VOLT = "volt"
     WATT = "watt"
     WEBER = "weber"
+
+
+# Rebuild all the classes within this file
+for cls in [
+    EnzymeMLDocument,
+    Creator,
+    Vessel,
+    Protein,
+    Complex,
+    SmallMolecule,
+    Reaction,
+    ReactionElement,
+    Equation,
+    Variable,
+    Parameter,
+    Measurement,
+    MeasurementData,
+    UnitDefinition,
+    BaseUnit,
+]:
+    cls.model_rebuild()

--- a/schemes/v2/enzymeml-v2-linkml.yaml
+++ b/schemes/v2/enzymeml-v2-linkml.yaml
@@ -11,6 +11,7 @@ imports:
 classes:
   EnzymeMLDocument:
     description: This is the root object that composes all objects found in an EnzymeML document. It also includes general metadata such as the name of the document, when it was created/modified, and references to publications, databases, and arbitrary links to the web.
+    tree_root: true
     attributes:
       name:
         description: Title of the EnzymeML Document.
@@ -21,6 +22,8 @@ classes:
         slot_uri: schema:citation
         identifier: true
         multivalued: true
+      description:
+        description: Free-text field for further desctiptions of the experiment and dataset.
       created:
         description: Date the EnzymeML document was created.
         slot_uri: schema:dateCreated
@@ -176,6 +179,8 @@ classes:
       constant:
         required: true
         range: boolean
+      synonymous_names:
+        multivalued: true
       vessel_id:
         description: Unique identifier of the vessel this small molecule has been used in.
         slot_uri: schema:identifier

--- a/schemes/v2/enzymeml-v2.graphql
+++ b/schemes/v2/enzymeml-v2.graphql
@@ -12,6 +12,7 @@
 type EnzymeMLDocument {
   name: String!
   references: [String]
+  description: String
   created: String
   modified: String
   creators: [Creator]
@@ -63,6 +64,7 @@ type SmallMolecule {
   id: String!
   name: String!
   constant: Boolean!
+  synonymous_names: [String]
   vessel_id: String
   canonical_smiles: String
   inchi: String
@@ -204,21 +206,19 @@ enum UnitType {
 type Query {
 
   # EnzymeMLDocument queries
-  enzymemldocument(id: ID!): EnzymeMLDocument
   allEnzymeMLDocuments: [EnzymeMLDocument]
   enzymemldocumentByName(name: String): [EnzymeMLDocument]
+  enzymemldocumentByDescription(description: String): [EnzymeMLDocument]
   enzymemldocumentByCreated(created: String): [EnzymeMLDocument]
   enzymemldocumentByModified(modified: String): [EnzymeMLDocument]
 
   # Creator queries
-  creator(id: ID!): Creator
   allCreators: [Creator]
   creatorByGiven_name(given_name: String): [Creator]
   creatorByFamily_name(family_name: String): [Creator]
   creatorByMail(mail: String): [Creator]
 
   # Vessel queries
-  vessel(id: ID!): Vessel
   allVessels: [Vessel]
   vesselById(id: String): [Vessel]
   vesselByName(name: String): [Vessel]
@@ -226,7 +226,6 @@ type Query {
   vesselByConstant(constant: Boolean): [Vessel]
 
   # Protein queries
-  protein(id: ID!): Protein
   allProteins: [Protein]
   proteinById(id: String): [Protein]
   proteinByName(name: String): [Protein]
@@ -238,7 +237,6 @@ type Query {
   proteinByOrganism_tax_id(organism_tax_id: String): [Protein]
 
   # Complex queries
-  complex(id: ID!): Complex
   allComplexs: [Complex]
   complexById(id: String): [Complex]
   complexByName(name: String): [Complex]
@@ -246,7 +244,6 @@ type Query {
   complexByVessel_id(vessel_id: String): [Complex]
 
   # SmallMolecule queries
-  smallmolecule(id: ID!): SmallMolecule
   allSmallMolecules: [SmallMolecule]
   smallmoleculeById(id: String): [SmallMolecule]
   smallmoleculeByName(name: String): [SmallMolecule]
@@ -257,34 +254,29 @@ type Query {
   smallmoleculeByInchikey(inchikey: String): [SmallMolecule]
 
   # Reaction queries
-  reaction(id: ID!): Reaction
   allReactions: [Reaction]
   reactionById(id: String): [Reaction]
   reactionByName(name: String): [Reaction]
   reactionByReversible(reversible: Boolean): [Reaction]
 
   # ReactionElement queries
-  reactionelement(id: ID!): ReactionElement
   allReactionElements: [ReactionElement]
   reactionelementBySpecies_id(species_id: String): [ReactionElement]
   reactionelementByStoichiometry(stoichiometry: Float): [ReactionElement]
 
   # Equation queries
-  equation(id: ID!): Equation
   allEquations: [Equation]
   equationByEquation(equation: String): [Equation]
   equationByEquation_type(equation_type: EquationType): [Equation]
   equationBySpecies_id(species_id: String): [Equation]
 
   # Variable queries
-  variable(id: ID!): Variable
   allVariables: [Variable]
   variableById(id: String): [Variable]
   variableByName(name: String): [Variable]
   variableBySymbol(symbol: String): [Variable]
 
   # Parameter queries
-  parameter(id: ID!): Parameter
   allParameters: [Parameter]
   parameterById(id: String): [Parameter]
   parameterByName(name: String): [Parameter]
@@ -297,7 +289,6 @@ type Query {
   parameterByConstant(constant: Boolean): [Parameter]
 
   # Measurement queries
-  measurement(id: ID!): Measurement
   allMeasurements: [Measurement]
   measurementById(id: String): [Measurement]
   measurementByName(name: String): [Measurement]
@@ -306,7 +297,6 @@ type Query {
   measurementByTemperature(temperature: Float): [Measurement]
 
   # MeasurementData queries
-  measurementdata(id: ID!): MeasurementData
   allMeasurementDatas: [MeasurementData]
   measurementdataBySpecies_id(species_id: String): [MeasurementData]
   measurementdataByInitial(initial: Float): [MeasurementData]
@@ -315,13 +305,11 @@ type Query {
   measurementdataByIs_simulated(is_simulated: Boolean): [MeasurementData]
 
   # UnitDefinition queries
-  unitdefinition(id: ID!): UnitDefinition
   allUnitDefinitions: [UnitDefinition]
   unitdefinitionById(id: String): [UnitDefinition]
   unitdefinitionByName(name: String): [UnitDefinition]
 
   # BaseUnit queries
-  baseunit(id: ID!): BaseUnit
   allBaseUnits: [BaseUnit]
   baseunitByKind(kind: UnitType): [BaseUnit]
   baseunitByExponent(exponent: Int): [BaseUnit]

--- a/schemes/v2/enzymeml-v2.graphql
+++ b/schemes/v2/enzymeml-v2.graphql
@@ -214,8 +214,8 @@ type Query {
 
   # Creator queries
   allCreators: [Creator]
-  creatorByGiven_name(given_name: String): [Creator]
-  creatorByFamily_name(family_name: String): [Creator]
+  creatorByGivenName(given_name: String): [Creator]
+  creatorByFamilyName(family_name: String): [Creator]
   creatorByMail(mail: String): [Creator]
 
   # Vessel queries
@@ -231,25 +231,25 @@ type Query {
   proteinByName(name: String): [Protein]
   proteinByConstant(constant: Boolean): [Protein]
   proteinBySequence(sequence: String): [Protein]
-  proteinByVessel_id(vessel_id: String): [Protein]
+  proteinByVesselId(vessel_id: String): [Protein]
   proteinByEcnumber(ecnumber: String): [Protein]
   proteinByOrganism(organism: String): [Protein]
-  proteinByOrganism_tax_id(organism_tax_id: String): [Protein]
+  proteinByOrganismTaxId(organism_tax_id: String): [Protein]
 
   # Complex queries
   allComplexs: [Complex]
   complexById(id: String): [Complex]
   complexByName(name: String): [Complex]
   complexByConstant(constant: Boolean): [Complex]
-  complexByVessel_id(vessel_id: String): [Complex]
+  complexByVesselId(vessel_id: String): [Complex]
 
   # SmallMolecule queries
   allSmallMolecules: [SmallMolecule]
   smallmoleculeById(id: String): [SmallMolecule]
   smallmoleculeByName(name: String): [SmallMolecule]
   smallmoleculeByConstant(constant: Boolean): [SmallMolecule]
-  smallmoleculeByVessel_id(vessel_id: String): [SmallMolecule]
-  smallmoleculeByCanonical_smiles(canonical_smiles: String): [SmallMolecule]
+  smallmoleculeByVesselId(vessel_id: String): [SmallMolecule]
+  smallmoleculeByCanonicalSmiles(canonical_smiles: String): [SmallMolecule]
   smallmoleculeByInchi(inchi: String): [SmallMolecule]
   smallmoleculeByInchikey(inchikey: String): [SmallMolecule]
 
@@ -261,14 +261,14 @@ type Query {
 
   # ReactionElement queries
   allReactionElements: [ReactionElement]
-  reactionelementBySpecies_id(species_id: String): [ReactionElement]
+  reactionelementBySpeciesId(species_id: String): [ReactionElement]
   reactionelementByStoichiometry(stoichiometry: Float): [ReactionElement]
 
   # Equation queries
   allEquations: [Equation]
   equationByEquation(equation: String): [Equation]
-  equationByEquation_type(equation_type: EquationType): [Equation]
-  equationBySpecies_id(species_id: String): [Equation]
+  equationByEquationType(equation_type: EquationType): [Equation]
+  equationBySpeciesId(species_id: String): [Equation]
 
   # Variable queries
   allVariables: [Variable]
@@ -282,7 +282,7 @@ type Query {
   parameterByName(name: String): [Parameter]
   parameterBySymbol(symbol: String): [Parameter]
   parameterByValue(value: Float): [Parameter]
-  parameterByInitial_value(initial_value: Float): [Parameter]
+  parameterByInitialValue(initial_value: Float): [Parameter]
   parameterByUpper(upper: Float): [Parameter]
   parameterByLower(lower: Float): [Parameter]
   parameterByStderr(stderr: Float): [Parameter]
@@ -292,17 +292,17 @@ type Query {
   allMeasurements: [Measurement]
   measurementById(id: String): [Measurement]
   measurementByName(name: String): [Measurement]
-  measurementByGroup_id(group_id: String): [Measurement]
+  measurementByGroupId(group_id: String): [Measurement]
   measurementByPh(ph: Float): [Measurement]
   measurementByTemperature(temperature: Float): [Measurement]
 
   # MeasurementData queries
   allMeasurementDatas: [MeasurementData]
-  measurementdataBySpecies_id(species_id: String): [MeasurementData]
+  measurementdataBySpeciesId(species_id: String): [MeasurementData]
   measurementdataByInitial(initial: Float): [MeasurementData]
-  measurementdataByData_type(data_type: DataTypes): [MeasurementData]
+  measurementdataByDataType(data_type: DataTypes): [MeasurementData]
   measurementdataByPrepared(prepared: Float): [MeasurementData]
-  measurementdataByIs_simulated(is_simulated: Boolean): [MeasurementData]
+  measurementdataByIsSimulated(is_simulated: Boolean): [MeasurementData]
 
   # UnitDefinition queries
   allUnitDefinitions: [UnitDefinition]

--- a/schemes/v2/enzymeml-v2.json
+++ b/schemes/v2/enzymeml-v2.json
@@ -7,8 +7,8 @@
   "properties": {
     "complexes": {
       "title": "complexes",
-      "type": "array",
       "description": "Contains all complexes that are part of the experiment.",
+      "$ref": "#/$defs/Complex",
       "items": {
         "$ref": "#/$defs/Complex"
       }
@@ -21,25 +21,30 @@
     },
     "creators": {
       "title": "creators",
-      "type": "array",
       "description": "Contains all authors that are part of the experiment.",
       "$term": "https://schema.org/creator",
+      "$ref": "#/$defs/Creator",
       "items": {
         "$ref": "#/$defs/Creator"
       }
     },
+    "description": {
+      "title": "description",
+      "type": "string",
+      "description": "Free-text field for further desctiptions of the experiment and dataset."
+    },
     "equations": {
       "title": "equations",
-      "type": "array",
       "description": "Contains ordinary differential equations that describe the kinetic model.",
+      "$ref": "#/$defs/Equation",
       "items": {
         "$ref": "#/$defs/Equation"
       }
     },
     "measurements": {
       "title": "measurements",
-      "type": "array",
       "description": "Contains measurements that describe outcomes of an experiment.",
+      "$ref": "#/$defs/Measurement",
       "items": {
         "$ref": "#/$defs/Measurement"
       }
@@ -58,24 +63,24 @@
     },
     "parameters": {
       "title": "parameters",
-      "type": "array",
       "description": "List of parameters that are part of the equation",
+      "$ref": "#/$defs/Parameter",
       "items": {
         "$ref": "#/$defs/Parameter"
       }
     },
     "proteins": {
       "title": "proteins",
-      "type": "array",
       "description": "Contains all proteins that are part of the experiment.",
+      "$ref": "#/$defs/Protein",
       "items": {
         "$ref": "#/$defs/Protein"
       }
     },
     "reactions": {
       "title": "reactions",
-      "type": "array",
       "description": "Dictionary mapping from reaction IDs to reaction-describing objects.",
+      "$ref": "#/$defs/Reaction",
       "items": {
         "$ref": "#/$defs/Reaction"
       }
@@ -91,16 +96,16 @@
     },
     "small_molecules": {
       "title": "small_molecules",
-      "type": "array",
       "description": "Contains all reactants that are part of the experiment.",
+      "$ref": "#/$defs/SmallMolecule",
       "items": {
         "$ref": "#/$defs/SmallMolecule"
       }
     },
     "vessels": {
       "title": "vessels",
-      "type": "array",
       "description": "Contains all vessels that are part of the experiment.",
+      "$ref": "#/$defs/Vessel",
       "items": {
         "$ref": "#/$defs/Vessel"
       }
@@ -246,8 +251,8 @@
         },
         "variables": {
           "title": "variables",
-          "type": "array",
           "description": "List of variables that are part of the equation",
+          "$ref": "#/$defs/Variable",
           "items": {
             "$ref": "#/$defs/Variable"
           }
@@ -299,8 +304,8 @@
         },
         "species_data": {
           "title": "species_data",
-          "type": "array",
           "description": "Measurement data of all species that were part of the measurement. A species can refer to a protein, complex, or small molecule.",
+          "$ref": "#/$defs/MeasurementData",
           "items": {
             "$ref": "#/$defs/MeasurementData"
           }
@@ -312,7 +317,6 @@
         },
         "temperature_unit": {
           "title": "temperature_unit",
-          "type": "object",
           "description": "Unit of the temperature of the measurement.",
           "$ref": "#/$defs/UnitDefinition"
         }
@@ -343,7 +347,6 @@
         },
         "data_unit": {
           "title": "data_unit",
-          "type": "object",
           "description": "SI unit of the data that was measured.",
           "$ref": "#/$defs/UnitDefinition"
         },
@@ -377,7 +380,6 @@
         },
         "time_unit": {
           "title": "time_unit",
-          "type": "object",
           "description": "Time unit of the replicate.",
           "$ref": "#/$defs/UnitDefinition"
         }
@@ -434,7 +436,6 @@
         },
         "unit": {
           "title": "unit",
-          "type": "object",
           "description": "Unit of the estimated parameter.",
           "$ref": "#/$defs/UnitDefinition"
         },
@@ -534,7 +535,6 @@
         },
         "kinetic_law": {
           "title": "kinetic_law",
-          "type": "object",
           "description": "Mathematical expression of the reaction.",
           "$ref": "#/$defs/Equation"
         },
@@ -558,8 +558,8 @@
         },
         "species": {
           "title": "species",
-          "type": "array",
           "description": "List of reaction elements that are part of the reaction.",
+          "$ref": "#/$defs/ReactionElement",
           "items": {
             "$ref": "#/$defs/ReactionElement"
           }
@@ -639,6 +639,13 @@
             "type": "string"
           }
         },
+        "synonymous_names": {
+          "title": "synonymous_names",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "vessel_id": {
           "title": "vessel_id",
           "type": "string",
@@ -660,8 +667,8 @@
       "properties": {
         "base_units": {
           "title": "base_units",
-          "type": "array",
           "description": "Base units that define the unit.",
+          "$ref": "#/$defs/BaseUnit",
           "items": {
             "$ref": "#/$defs/BaseUnit"
           }
@@ -773,7 +780,6 @@
         },
         "unit": {
           "title": "unit",
-          "type": "object",
           "description": "Volumetric unit of the vessel.",
           "$ref": "#/$defs/UnitDefinition"
         },

--- a/schemes/v2/enzymeml-v2.proto
+++ b/schemes/v2/enzymeml-v2.proto
@@ -77,29 +77,32 @@ message EnzymeMLDocument {
   // Contains references to publications, databases, and arbitrary links to
   // the web.
   repeated string references = 2;
+  // Free-text field for further desctiptions of the experiment and
+  // dataset.
+  optional string description = 3;
   // Date the EnzymeML document was created.
-  optional string created = 3;
+  optional string created = 4;
   // Date the EnzymeML document was modified.
-  optional string modified = 4;
+  optional string modified = 5;
   // Contains all authors that are part of the experiment.
-  repeated Creator creators = 5;
+  repeated Creator creators = 6;
   // Contains all vessels that are part of the experiment.
-  repeated Vessel vessels = 6;
+  repeated Vessel vessels = 7;
   // Contains all proteins that are part of the experiment.
-  repeated Protein proteins = 7;
+  repeated Protein proteins = 8;
   // Contains all complexes that are part of the experiment.
-  repeated Complex complexes = 8;
+  repeated Complex complexes = 9;
   // Contains all reactants that are part of the experiment.
-  repeated SmallMolecule small_molecules = 9;
+  repeated SmallMolecule small_molecules = 10;
   // Dictionary mapping from reaction IDs to reaction-describing objects.
-  repeated Reaction reactions = 10;
+  repeated Reaction reactions = 11;
   // Contains measurements that describe outcomes of an experiment.
-  repeated Measurement measurements = 11;
+  repeated Measurement measurements = 12;
   // Contains ordinary differential equations that describe the kinetic
   // model.
-  repeated Equation equations = 12;
+  repeated Equation equations = 13;
   // List of parameters that are part of the equation
-  repeated Parameter parameters = 13;
+  repeated Parameter parameters = 14;
 }
 
 message Creator {
@@ -160,19 +163,20 @@ message SmallMolecule {
   string id = 1;
   string name = 2;
   boolean constant = 3;
+  repeated string synonymous_names = 4;
   // Unique identifier of the vessel this small molecule has been used in.
-  optional string vessel_id = 4;
+  optional string vessel_id = 5;
   // Canonical Simplified Molecular-Input Line-Entry System (SMILES)
   // encoding of the reactant.
-  optional string canonical_smiles = 5;
+  optional string canonical_smiles = 6;
   // International Chemical Identifier (InChI) encoding of the reactant.
-  optional string inchi = 6;
+  optional string inchi = 7;
   // Hashed International Chemical Identifier (InChIKey) encoding of the
   // reactant.
-  optional string inchikey = 7;
+  optional string inchikey = 8;
   // Array of references to publications, database entries, etc. that
   // describe the reactant.
-  repeated string references = 8;
+  repeated string references = 9;
 }
 
 message Reaction {

--- a/schemes/v2/enzymeml-v2.shex
+++ b/schemes/v2/enzymeml-v2.shex
@@ -1,7 +1,7 @@
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX enzml: <http://www.enzymeml.org/v2/>
-PREFIX OBO: <http://purl.obolibrary.org/obo/>
 PREFIX schema: <https://schema.org/>
+PREFIX OBO: <http://purl.obolibrary.org/obo/>
 
 enzml:EnzymeMLDocument {
     schema:title xsd:string {

--- a/schemes/v2/enzymeml-v2.xsd
+++ b/schemes/v2/enzymeml-v2.xsd
@@ -36,6 +36,14 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="description" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        Free-text field for further desctiptions of the experiment and
+                        dataset.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="created" type="xs:string">
                 <xs:annotation>
                     <xs:documentation>
@@ -329,6 +337,7 @@
             </xs:element>
             <xs:element name="name" type="xs:string"/>
             <xs:element name="constant" type="xs:boolean" default="false"/>
+            <xs:element name="synonymous_names" type="xs:string"  maxOccurs="unbounded"/>
             <xs:element name="vessel_id" type="xs:string">
                 <xs:annotation>
                     <xs:documentation>
@@ -758,7 +767,7 @@
 
     <!-- BaseUnit Definition -->
     <xs:complexType name="BaseUnitType">
-        <xs:attribute name="kind" type="xs:UnitType"  use="required">
+        <xs:attribute name="kind" type="UnitTypeType"  use="required">
             <xs:annotation>
                 <xs:documentation>
                     Kind of the base unit (e.g., meter, kilogram, second).

--- a/specifications/v2.md
+++ b/specifications/v2.md
@@ -24,6 +24,9 @@ This is the root object that composes all objects found in an EnzymeML document.
   - Type: Identifier[]
   - Description: Contains references to publications, databases, and arbitrary links to the web.
   - Term: schema:citation
+- description
+  - Type: string
+  - Description: Free-text field for further desctiptions of the experiment and dataset.
 - created
   - Type: string
   - Description: Date the EnzymeML document was created.
@@ -179,6 +182,8 @@ This object describes the reactants that were used or produced in the course of 
 - **constant**
   - Type: boolean
   - Default: False
+- synonymous_names
+  - Type: string[]
 - vessel_id
   - Type: Identifier
   - Description: Unique identifier of the vessel this small molecule has been used in.


### PR DESCRIPTION
This PR extends the data model of two additional fields:

* `EnzymeMLDocument.description`: A free-text description of the dataset and experiment.
* `SmallMolecule.synonymous_names`: An optional array field that allows the addition of synonymous names.

Happy to further discuss this here! @FabianMauz