### PR TITLE
Add AMOUNT to DataTypes enum

### DIFF
--- a/specifications/v2.md
+++ b/specifications/v2.md
@@ -344,4 +344,5 @@ CONVERSION = "conversion"
 PEAK_AREA = "peakarea"
 TRANSMITTANCE = "transmittance"
 FLUORESCENCE = "fluorescence"
+AMOUNT = "amount'
 ```


### PR DESCRIPTION
To accommodate masses and volumes as types of `MeasurementData`, `AMOUNT` is added to the `DataTypes` enum.