### PR TITLE
Introduce 'fit' parameter for optimization context

### DIFF
--- a/specifications/v2.md
+++ b/specifications/v2.md
@@ -358,6 +358,10 @@ This object describes parameters used in kinetic models, including estimated val
 - lower_bound
   - Type: float
   - Description: Lower bound for the parameter value that was used for the parameter estimation
+- fit
+  - Type: boolean
+  - Description: Whether this parameter should be varied or not in the context of an optimization.
+  - Default: True
 - stderr
   - Type: float
   - Description: Standard error of the estimated parameter.


### PR DESCRIPTION
This pull request adds a new parameter to the object describing kinetic model parameters. The change introduces a `fit` attribute to specify whether a parameter should be varied during optimization. Adding this will not break any previous EnzymeML documents due to the default.

Kinetic model parameter specification update:

* Added a `fit` boolean attribute to indicate if a parameter should be varied during optimization, with a default value of `True`